### PR TITLE
Broaden Submit/Add-Your-Model links + swap Mason/Jason to ID-spelling example

### DIFF
--- a/leaderboard/src/App.jsx
+++ b/leaderboard/src/App.jsx
@@ -62,7 +62,7 @@ export default function App() {
                             Dataset
                         </a>
                         <a
-                            href="https://github.com/sierra-research/mu-bench/blob/main/submissions/SUBMITTING.md"
+                            href="https://github.com/sierra-research/mu-bench"
                             target="_blank"
                             rel="noopener noreferrer"
                             className="navbar-link"

--- a/leaderboard/src/components/Leaderboard.jsx
+++ b/leaderboard/src/components/Leaderboard.jsx
@@ -283,15 +283,15 @@ export default function Leaderboard() {
                         <span className="action-card-title">Add Your Model</span>
                         <span className="action-card-desc">
                             Submit your model's transcripts and they will be automatically scored and ranked. See the
-                            submission guide for formatting and step-by-step instructions.
+                            GitHub for the formatting guidelines and detailed submission instructions.
                         </span>
                         <a
                             className="action-card-btn"
-                            href="https://github.com/sierra-research/mu-bench/blob/main/submissions/SUBMITTING.md"
+                            href="https://github.com/sierra-research/mu-bench"
                             target="_blank"
                             rel="noopener noreferrer"
                         >
-                            Submission Instructions
+                            View on GitHub
                         </a>
                     </div>
                     <div className="action-card">

--- a/leaderboard/src/components/PaperErrorExamples.jsx
+++ b/leaderboard/src/components/PaperErrorExamples.jsx
@@ -18,11 +18,11 @@ const EXAMPLES = [
         id: "significant",
         title: "Significant Errors (Low WER, High UER)",
         description:
-            "Only one word differs in each transcription, but the person\u2019s name is wrong \u2014 a single substitution that changes meaning entirely.",
-        gold: "The name on the account is Mason Lee.",
+            "The caller is spelling out a case tracking code. Only one letter differs in each transcription, but that single substitution points to the wrong case entirely \u2014 exactly the kind of error a fluent-sounding ASR output can hide.",
+        gold: "My case tracking code is C N 7 3 4 7 8 5 8.",
         predictions: {
-            "Provider A": "The name on the account is Jason Lee.",
-            "Provider B": "The name on the account is Mason Li.",
+            "Provider A": "My case tracking code is C M 7 3 4 7 8 5 8.",
+            "Provider B": "My case tracking code is D N 7 3 4 7 8 5 8.",
         },
         locale: "en-US",
     },


### PR DESCRIPTION
## Summary

- **Nav links.** Top-right \"Submit\" tab and the \"Add Your Model\" action card now link to the GitHub repo root (`github.com/sierra-research/mu-bench`) instead of deep-linking to `SUBMITTING.md`. Visitors land on a more general orientation page and can navigate to the submission guide themselves.
- **Blog example.** The \"Significant Errors (Low WER, High UER)\" interactive example in the blog/paper has been swapped from a name substitution (Mason → Jason) to a caller spelling out a case tracking code (\"C N 7 3 4 7 8 5 8\"), with one provider mishearing N→M and another C→D. Classic 8kHz telephony letter confusions, and matches the benchmark's real banking-domain utterances.

The provider row-detail footer link still deep-links to SUBMITTING.md (intentionally — when a visitor has clicked into a specific model, \"Submit your own model →\" should point straight at the submission contract).

## Test plan

- [ ] Leaderboard builds clean (`npm run build` in \`leaderboard/\`).
- [ ] After deploy, click \"Submit\" in top nav → lands on repo root.
- [ ] Click \"Add Your Model\" action card on home → lands on repo root.
- [ ] Scroll to Errors section in the blog → \"Significant Errors\" card shows tracking code with one-letter diffs on each provider tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)