### PR TITLE
Fix high-priority issues for open-source launch

### DIFF
--- a/.github/workflows/deploy-leaderboard.yml
+++ b/.github/workflows/deploy-leaderboard.yml
@@ -31,12 +31,12 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Inject leaderboard data
-        run: node leaderboard/scripts/inject-data.js
-
       - name: Install dependencies
         working-directory: leaderboard
         run: npm ci
+
+      - name: Inject leaderboard data
+        run: node leaderboard/scripts/inject-data.js
 
       - name: Build
         working-directory: leaderboard

--- a/.github/workflows/post-merge-score.yml
+++ b/.github/workflows/post-merge-score.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: post-merge-score
+  cancel-in-progress: false
+
 jobs:
   score-and-commit:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/score-submission.yml
+++ b/.github/workflows/score-submission.yml
@@ -5,7 +5,7 @@ on:
     types: [created]
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 
 concurrency:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,31 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers at **soham@sierra.ai**. All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to MU-Bench
+
+Thank you for your interest in contributing to MU-Bench!
+
+## Submitting benchmark results
+
+If you want to add your model to the leaderboard, see **[`submissions/SUBMITTING.md`](submissions/SUBMITTING.md)** for the full submission format and process.
+
+## Reporting issues
+
+- **Bugs or scoring questions** — [Open a GitHub issue](https://github.com/sierra-research/mu-bench/issues)
+- **Security vulnerabilities** — See [SECURITY.md](SECURITY.md)
+
+## Contributing code or documentation
+
+1. Fork the repo and create a branch from `main`.
+2. Install dev dependencies:
+
+```bash
+pip install -e ".[scoring]"
+pre-commit install
+```
+
+3. Make your changes. The codebase uses:
+   - **Python**: [ruff](https://docs.astral.sh/ruff/) for linting and formatting
+   - **Leaderboard (JS)**: eslint + prettier — run `npm run lint` and `npm run format:check` in `leaderboard/`
+
+4. Run validation locally if you touched scoring or submission code:
+
+```bash
+python scoring/validate.py submissions/raw/deepgram-nova3 --manifest manifest.json
+```
+
+5. Open a pull request. CI will run linting and validation automatically.
+
+## Code style
+
+- Python: `ruff` handles both linting and formatting. Pre-commit hooks run automatically if installed.
+- JavaScript: Prettier for formatting, ESLint for linting. Both are configured in `leaderboard/`.
+
+## What needs `scoring/prompts.py`?
+
+The file `scoring/prompts.py` contains LLM prompt templates and is **not included in the repo** — it's injected via GitHub secret in CI. You do **not** need it for:
+
+- Running `scoring/validate.py`
+- Importing `scoring.metrics` (WER, simple WER, data classes)
+- Importing `scoring.normalize.load_ground_truth_from_manifest`
+
+You **do** need it for running the full normalization or scoring pipeline (LLM-based functions).

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,17 @@
+Dual License
+
+This repository uses a dual-license model:
+
+  * CODE (scripts, scoring, leaderboard, workflows, and all other software)
+    is licensed under the Apache License 2.0 (full text below).
+
+  * DATA (audio files, transcripts, and manifest.json from the HuggingFace
+    dataset sierra-research/mu-bench) is licensed under the Creative Commons
+    Attribution-NonCommercial 4.0 International License (CC BY-NC 4.0).
+    Full text: https://creativecommons.org/licenses/by-nc/4.0/legalcode
+
+================================================================================
+
 Copyright 2026 Sierra Technologies, Inc.
 
                                  Apache License

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it responsibly:
+
+1. **Do not** open a public GitHub issue.
+2. Email **soham@sierra.ai** with a description of the vulnerability, steps to reproduce, and any relevant details.
+3. We will acknowledge receipt within 48 hours and provide an estimated timeline for a fix.
+
+## Scope
+
+This policy covers the MU-Bench repository, CI workflows, and the leaderboard web application. It does not cover the HuggingFace dataset hosting infrastructure.


### PR DESCRIPTION
## Summary

Fixes items 5-9 from the OSS readiness audit.

### 5. Standard community files
- **`CONTRIBUTING.md`** — points to SUBMITTING.md for benchmarks, documents dev setup (ruff, pre-commit, eslint), explains what needs `scoring/prompts.py`
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1
- **`SECURITY.md`** — responsible disclosure instructions

### 6. Dual-license in LICENSE file
Added preamble to `LICENSE` explicitly stating Apache 2.0 for code, CC BY-NC 4.0 for data. Previously only in README prose — now GitHub's license detector and legal reviewers see it in the actual license file.

### 7. Post-merge scoring race condition
Added `concurrency: { group: post-merge-score, cancel-in-progress: false }` so two quick merges queue instead of racing on `git push`.

### 8. Deploy workflow step order
Swapped `npm ci` before `inject-data.js` so `npx prettier` in the inject script uses the locally installed package instead of downloading on the fly.

### 9. Tighter CI permissions
Dropped `contents: write` from `score-submission.yml` (only posts PR comments, never pushes). Now `contents: read`.

## Test plan

- [ ] Verify CI lint passes
- [ ] Verify deploy workflow still builds correctly (npm ci → inject → build)
- [ ] Verify post-merge-score serializes on concurrent merges

Made with [Cursor](https://cursor.com)