### PR TITLE
Note HuggingFace-published LLM prompt templates in README + SUBMITTING

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Audio files land in `audio/<locale>/`.
 | **UER** (Utterance Error Rate) | Lower is better | Fraction of utterances containing at least one meaning-changing error |
 | **Latency p95** | Lower is better | 95th percentile of per-request API response time (ms), measured at concurrency=1 |
 
-See [`submissions/SUBMITTING.md`](submissions/SUBMITTING.md) for how each metric is computed.
+The LLM prompt templates used for normalization and scoring are published alongside the audio on the HuggingFace dataset: [`sierra-research/mu-bench/blob/main/scoring/prompts.py`](https://huggingface.co/datasets/sierra-research/mu-bench/blob/main/scoring/prompts.py). See [`submissions/SUBMITTING.md`](submissions/SUBMITTING.md) for how each metric is computed.
 
 ## Repository Structure
 

--- a/submissions/SUBMITTING.md
+++ b/submissions/SUBMITTING.md
@@ -84,7 +84,7 @@ The validator checks directory structure, file encoding, metadata fields, latenc
 2. **A maintainer will review and comment `/score`** to run the scoring pipeline (WER, Utterance Error Rate, Latency p95). Results are posted back as a PR comment.
 3. **On merge**, `post-merge-score.yml` re-scores from scratch, commits `results/<your-model-name>/` and `submissions/normalized/<your-model-name>/` to main, and the leaderboard redeploys with your model added.
 
-Scoring requires an OpenAI key (for the LLM-based normalization pass), so you can't run the full pipeline in this repo locally — `scoring/validate.py` is the most comprehensive local check we support. The LLM prompt templates themselves are fully public: they're published alongside the audio on the HuggingFace dataset at [`sierra-research/mu-bench/blob/main/scoring/prompts.py`](https://huggingface.co/datasets/sierra-research/mu-bench/blob/main/scoring/prompts.py), so you can reproduce our scoring end-to-end with your own OpenAI key if you want.
+Scoring requires an OpenAI key so you can't run the full pipeline in this repo locally — `scoring/validate.py` is the most comprehensive local check we support. The LLM prompt templates themselves are published alongside the audio on the HuggingFace dataset at [`sierra-research/mu-bench/blob/main/scoring/prompts.py`](https://huggingface.co/datasets/sierra-research/mu-bench/blob/main/scoring/prompts.py).
 
 ## How we measure
 

--- a/submissions/SUBMITTING.md
+++ b/submissions/SUBMITTING.md
@@ -84,7 +84,7 @@ The validator checks directory structure, file encoding, metadata fields, latenc
 2. **A maintainer will review and comment `/score`** to run the scoring pipeline (WER, Utterance Error Rate, Latency p95). Results are posted back as a PR comment.
 3. **On merge**, `post-merge-score.yml` re-scores from scratch, commits `results/<your-model-name>/` and `submissions/normalized/<your-model-name>/` to main, and the leaderboard redeploys with your model added.
 
-Scoring requires secrets that aren't available locally (LLM-based normalization prompts + an OpenAI key), so you can't run the full pipeline yourself — `scoring/validate.py` is the most comprehensive local check we support.
+Scoring requires an OpenAI key (for the LLM-based normalization pass), so you can't run the full pipeline in this repo locally — `scoring/validate.py` is the most comprehensive local check we support. The LLM prompt templates themselves are fully public: they're published alongside the audio on the HuggingFace dataset at [`sierra-research/mu-bench/blob/main/scoring/prompts.py`](https://huggingface.co/datasets/sierra-research/mu-bench/blob/main/scoring/prompts.py), so you can reproduce our scoring end-to-end with your own OpenAI key if you want.
 
 ## How we measure
 


### PR DESCRIPTION
## Summary

Surface the fact that the scoring prompt templates (\`scoring/prompts.py\`) are published alongside the audio on the HuggingFace dataset: https://huggingface.co/datasets/sierra-research/mu-bench/blob/main/scoring/prompts.py

Updates:
- **README.md** — adds a line under the Metrics table pointing to the HF-hosted prompts.
- **submissions/SUBMITTING.md** — reframes the \"Scoring requires secrets\" note: prompts are public on HF, only an OpenAI key is needed to reproduce scoring locally.

## Test plan

- [ ] Links resolve to the HF blob.
- [ ] Markdown renders as expected on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)