### PR TITLE
Bold M and U in hero subtitle

### DIFF
--- a/leaderboard/src/App.jsx
+++ b/leaderboard/src/App.jsx
@@ -88,7 +88,9 @@ export default function App() {
                                     <span className="mu-symbol">&mu;</span>
                                     <span className="bench-text">-bench</span>
                                 </h1>
-                                <p className="hero-subtitle">Multilingual Utterances Transcription Benchmark</p>
+                                <p className="hero-subtitle">
+                                    <strong>M</strong>ultilingual <strong>U</strong>tterances Transcription Benchmark
+                                </p>
                             </section>
                         </div>
                         <Leaderboard />


### PR DESCRIPTION
## Summary

Adds visual emphasis on the \"MU\" origin of MU-Bench in the front-page subtitle by wrapping the M and U in `<strong>` tags:

Before: \"Multilingual Utterances Transcription Benchmark\"
After: \"**M**ultilingual **U**tterances Transcription Benchmark\"

Uses plain `<strong>` (no color change) to match the existing hero-subtitle styling.

## Test plan

- [ ] After deploy, front page subtitle renders with bold M and bold U.

🤖 Generated with [Claude Code](https://claude.com/claude-code)