### PR TITLE
Fix medium-priority issues for open-source launch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+# Python linting and formatting (ruff)
+# For leaderboard JS: run `cd leaderboard && npm run lint && npm run format:check`
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.9

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # MU-Bench
 
+[![License: Apache 2.0](https://img.shields.io/badge/Code-Apache%202.0-blue.svg)](LICENSE)
+[![License: CC BY-NC 4.0](https://img.shields.io/badge/Data-CC%20BY--NC%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-nc/4.0/)
+[![CI](https://github.com/sierra-research/mu-bench/actions/workflows/lint.yml/badge.svg)](https://github.com/sierra-research/mu-bench/actions/workflows/lint.yml)
+[![Dataset on HF](https://img.shields.io/badge/🤗-Dataset-yellow.svg)](https://huggingface.co/datasets/sierra-research/mu-bench)
+
 **M**ultilingual **U**tterances Transcription Benchmark — an open benchmark for evaluating speech-to-text providers across multiple locales and metrics.
+
+**[Leaderboard](https://research.sierra.ai)** · **[Dataset](https://huggingface.co/datasets/sierra-research/mu-bench)** · **[Blog](https://research.sierra.ai/mubench/#paper)**
 
 ## Overview
 
@@ -16,71 +23,119 @@ The dataset covers 5 locales with 4,270 utterances total:
 | vi-VN | Vietnamese | 975 |
 | zh-CN | Chinese (Mandarin) | 840 |
 
-Live leaderboard: [research.sierra.ai/mubench](https://research.sierra.ai/mubench)
+## Getting Started
 
-## For Submitters (Benchmarking Your Model)
-
-If you want to evaluate your speech-to-text model on MU-Bench, read **[`submissions/SUBMITTING.md`](submissions/SUBMITTING.md)**. The short version:
-
-1. Request access to the [HuggingFace dataset](https://huggingface.co/datasets/sierra-research/mu-bench) and download the audio.
-2. Run your model, producing one `.txt` per utterance plus a `latency.json`.
-3. Drop a directory under `submissions/raw/<your-model-name>/` and open a PR.
-4. CI validates the format; a maintainer comments `/score` to run scoring; the leaderboard redeploys on merge.
-
-### Local validation (before opening a PR)
+### 1. Install System Dependencies
 
 ```bash
-pip install pyyaml              # or: pip install -e . from the repo root
-python scoring/validate.py submissions/raw/<your-model-name> --manifest manifest.json
+brew install ffmpeg   # macOS
+# or: apt-get install ffmpeg   # Linux
 ```
 
-### Downloading the audio
+### 2. Download Audio
+
+The audio is hosted as a gated dataset on HuggingFace. You'll need to:
+
+1. [Request access](https://huggingface.co/datasets/sierra-research/mu-bench) to the `sierra-research/mu-bench` dataset
+2. Create a [HuggingFace token](https://huggingface.co/settings/tokens) and set it as an environment variable
 
 ```bash
 export HF_TOKEN=your_token_here
-pip install -e .[tools]
+pip install -r scripts/requirements.txt
 python scripts/download_audio.py
 ```
 
-Audio files land in `audio/<locale>/`.
+This exports `.wav` files to `audio/<locale>/`.
 
-## Metrics
+### 3. View the Leaderboard Locally
 
-| Metric | Direction | Description |
-|---|---|---|
-| **WER** (Word Error Rate) | Lower is better | Percentage of words incorrectly transcribed after LLM normalization |
-| **UER** (Utterance Error Rate) | Lower is better | Fraction of utterances containing at least one meaning-changing error |
-| **Latency p95** | Lower is better | 95th percentile of per-request API response time (ms), measured at concurrency=1 |
+```bash
+cd leaderboard
+npm install
+npm run dev
+```
 
-See [`submissions/SUBMITTING.md`](submissions/SUBMITTING.md) for how each metric is computed.
+### 4. Explore the Manifest
+
+`manifest.json` contains every utterance in the benchmark with its ground truth transcript:
+
+```json
+{
+  "id": "conv-0-turn-0",
+  "locale": "en-US",
+  "conversation_id": "conv-0",
+  "turn_index": 0,
+  "transcript": "Hi. I'm calling to check the status of my card.",
+  "audio_path": "audio/en-US/conv-0-turn-0.wav",
+  "duration_sec": 2.246
+}
+```
+
+## Submitting Results
+
+See **[`submissions/SUBMITTING.md`](submissions/SUBMITTING.md)** for the full submission contract. The short version:
+
+1. **Download the audio** from the [HuggingFace dataset](https://huggingface.co/datasets/sierra-research/mu-bench)
+2. **Run your model** on all audio files listed in `manifest.json`
+3. **Save transcripts** as `.txt` files — one per utterance, plain text, no headers
+4. **Create `metadata.yaml`** with your model info
+5. **Create `latency.json`** mapping `"<locale>/<utterance_id>"` to API response time in milliseconds
+6. **Validate locally** with `python scoring/validate.py submissions/raw/your-model-name --manifest manifest.json`
+7. **Open a pull request** adding your submission under `submissions/raw/`
+
+See `submissions/raw/deepgram-nova3/` for a complete example.
+
+### Scoring
+
+Scoring is run by maintainers — submitters do not need to run it locally. When a maintainer comments `/score` on your PR, the CI pipeline runs automatically:
+
+| Metric | Description | Direction |
+|--------|-------------|-----------|
+| **WER** | Word Error Rate after LLM normalization | Lower is better |
+| **UER** | Utterance Error Rate — fraction with meaning-changing errors | Lower is better |
+| **Quality Score** | LLM-judged quality on a 0-3 scale | Higher is better |
+| **Latency (p95)** | 95th percentile API response time per utterance (ms) | Lower is better |
+
+Results are posted as a comment on your PR and added to the leaderboard on merge.
 
 ## Repository Structure
 
 ```
-manifest.json                # Audio list + ground truth transcripts
-pyproject.toml               # Python deps (base, [tools], [scoring], [transcribe] extras)
-submissions/
-  SUBMITTING.md              # Submitter guide (read this first)
-  raw/                       # One dir per provider: .txt transcripts + latency.json + metadata.yaml
-  normalized/                # LLM-normalized transcripts (auto-generated on merge)
-scoring/
-  validate.py                # Submission format validation (run locally, also by CI)
-  normalize.py               # LLM-based transcript normalization (CI only)
-  score.py                   # WER / UER / quality computation (CI only)
-  metrics.py                 # Core metric implementations
-  update_leaderboard.py      # Regenerates results/leaderboard.json
+manifest.json              # Audio file list + ground truth transcripts
 scripts/
-  download_audio.py          # Fetch audio from HuggingFace
-  transcribe.py              # Example: run provider APIs end-to-end
-  latency_stats.py           # Compute p50/p95 and patch scores.json
-  compare_transcripts.py     # Diff two submission bases utterance-by-utterance
-  significance_test.py       # Statistical significance between providers
+  download_audio.py        # Download audio from HuggingFace
+  transcribe.py            # Runs provider APIs to generate transcripts + latency
+  latency_stats.py         # Compute p50/p95 latency from latency.json files
+  requirements.txt         # Python dependencies
+submissions/
+  SUBMITTING.md            # Full submission contract
+  raw/                     # Raw transcripts + latency.json, one directory per provider
+  normalized/              # LLM-normalized transcripts (auto-generated by CI)
+scoring/
+  validate.py              # Submission format validation (run locally)
+  normalize.py             # LLM-based transcript normalization
+  score.py                 # Metrics computation (WER, quality, sig. WER)
+  metrics.py               # Core metric implementations
+  prompts.py               # ⚠️ Gitignored — injected from GitHub secret in CI
 results/
-  leaderboard.json           # Aggregated leaderboard
-  <provider>/scores.json     # Per-provider breakdown
-  <provider>/details/        # Per-utterance scoring detail
-leaderboard/                 # React/Vite web app for the public leaderboard (maintainer concern)
-.github/workflows/           # CI for validation, scoring, and deployment
+  leaderboard.json         # Aggregated leaderboard data
+  <provider>/scores.json   # Per-provider score breakdowns (includes latency)
+leaderboard/               # React/Vite leaderboard web app
+.github/workflows/         # CI for validation, scoring, and deployment
+```
+
+## Citing MU-Bench
+
+If you use MU-Bench in your research, please cite:
+
+```bibtex
+@misc{mubench2026,
+  title     = {MU-Bench: A Multilingual Transcription Benchmark from Real Phone Calls},
+  author    = {Li, Andrea and Ray, Soham},
+  year      = {2026},
+  url       = {https://github.com/sierra-research/mu-bench},
+  note      = {Dataset: https://huggingface.co/datasets/sierra-research/mu-bench}
+}
 ```
 
 ## License

--- a/leaderboard/src/utils/metrics.js
+++ b/leaderboard/src/utils/metrics.js
@@ -21,11 +21,11 @@ export const METRICS = {
     qualityScore: {
         key: "qualityScore",
         label: "Quality",
-        fullLabel: "Quality Score (1-3)",
+        fullLabel: "Quality Score (0-3)",
         lowerIsBetter: false,
         format: (v) => v.toFixed(2),
         unit: "",
-        description: "LLM-judged overall transcription quality score (1\u20133)",
+        description: "LLM-judged overall transcription quality score (0\u20133)",
     },
     latencyP95Ms: {
         key: "latencyP95Ms",

--- a/scoring/llm.py
+++ b/scoring/llm.py
@@ -181,16 +181,15 @@ def load_responses(responses):
         List of parsed dicts (or None on parse error)
     """
     for i, response in enumerate(responses):
-        try:
-            if response is None:
-                responses[i] = None
-            else:
-                responses[i] = (
-                    json.loads(response.split("```json")[1].split("```")[0])
-                    if response.startswith("```json")
-                    else json.loads(response)
-                )
-        except Exception as e:
-            print(f"JSON parse error for response {i}: {e}")
+        if response is None:
             responses[i] = None
+            continue
+        try:
+            responses[i] = json.loads(response)
+        except json.JSONDecodeError:
+            try:
+                responses[i] = json.loads(response.split("```json")[1].split("```")[0])
+            except Exception as e:
+                print(f"JSON parse error for response {i}: {e}")
+                responses[i] = None
     return responses

--- a/scoring/normalize.py
+++ b/scoring/normalize.py
@@ -20,7 +20,6 @@ load_dotenv()
 
 from scoring.llm import NORMALIZE_SCHEMA, get_responses, load_responses
 from scoring.metrics import is_unintelligible
-from scoring.prompts import NORMALIZE_AGAINST_GOLD_PROMPT
 
 TARGET_LOCALES = ["en-US", "es-MX", "tr-TR", "vi-VN", "zh-CN"]
 
@@ -70,6 +69,8 @@ def load_transcript_pairs(
 
 
 def main():
+    from scoring.prompts import NORMALIZE_AGAINST_GOLD_PROMPT
+
     parser = argparse.ArgumentParser(description="LLM-normalize submission transcripts")
     parser.add_argument("--submission-dir", type=Path, required=True, help="Submission directory")
     parser.add_argument(
@@ -82,7 +83,7 @@ def main():
         "--output-dir",
         type=Path,
         default=None,
-        help="Output directory (default: submissions_normalized/<name>)",
+        help="Output directory (default: submissions/normalized/<name>)",
     )
     parser.add_argument("--num-workers", type=int, default=15, help="Parallel LLM workers")
     parser.add_argument("--locales", nargs="+", default=None, help="Limit to specific locales (e.g. en-US zh-CN)")

--- a/scoring/validate.py
+++ b/scoring/validate.py
@@ -47,31 +47,48 @@ def load_manifest(manifest_path):
 
 
 def validate_metadata(submission_dir):
-    """Validate metadata.yaml exists and has required fields."""
+    """Validate metadata.yaml (or metadata.json) exists and has required fields."""
     issues = []
     metadata_path = submission_dir / "metadata.yaml"
+    metadata_json_path = submission_dir / "metadata.json"
 
-    if not metadata_path.exists():
-        issues.append("metadata.yaml is missing (required)")
+    if not metadata_path.exists() and not metadata_json_path.exists():
+        issues.append("metadata.yaml (or metadata.json) is missing (required)")
         return issues
 
-    if yaml is None:
-        content = metadata_path.read_text(encoding="utf-8")
-        for field in REQUIRED_METADATA_FIELDS:
-            if f"{field}:" not in content and f"{field} :" not in content:
-                issues.append(f"metadata.yaml may be missing required field: {field}")
-        return issues
+    metadata = None
 
-    with open(metadata_path, "r", encoding="utf-8") as f:
-        metadata = yaml.safe_load(f)
+    if metadata_path.exists():
+        if yaml is None:
+            content = metadata_path.read_text(encoding="utf-8")
+            for field in REQUIRED_METADATA_FIELDS:
+                if f"{field}:" not in content and f"{field} :" not in content:
+                    issues.append(f"metadata.yaml may be missing required field: {field}")
+            return issues
 
-    if not isinstance(metadata, dict):
-        issues.append("metadata.yaml is not a valid YAML mapping")
-        return issues
+        with open(metadata_path, "r", encoding="utf-8") as f:
+            metadata = yaml.safe_load(f)
+
+        if not isinstance(metadata, dict):
+            issues.append("metadata.yaml is not a valid YAML mapping")
+            return issues
+    elif metadata_json_path.exists():
+        import json as _json
+
+        try:
+            with open(metadata_json_path, "r", encoding="utf-8") as f:
+                metadata = _json.load(f)
+        except Exception as e:
+            issues.append(f"metadata.json is not valid JSON: {e}")
+            return issues
+
+        if not isinstance(metadata, dict):
+            issues.append("metadata.json is not a valid JSON object")
+            return issues
 
     for field in REQUIRED_METADATA_FIELDS:
         if field not in metadata or metadata[field] is None or str(metadata[field]).strip() == "":
-            issues.append(f"metadata.yaml missing required field: {field}")
+            issues.append(f"metadata missing required field: {field}")
 
     return issues
 

--- a/scripts/transcribe.py
+++ b/scripts/transcribe.py
@@ -133,17 +133,32 @@ DEEPGRAM_LOCALE_MAP = {
     "zh-CN": "zh",
 }
 
+MAX_RETRIES = 3
+RETRY_BACKOFF = 2.0
+RETRYABLE_STATUSES = {429, 500, 502, 503, 529}
+
+
+async def _post_with_retry(session: aiohttp.ClientSession, url: str, headers: dict, data, provider: str):
+    """POST with exponential backoff on rate-limit and server errors."""
+    for attempt in range(MAX_RETRIES):
+        async with session.post(url, headers=headers, data=data) as resp:
+            if resp.status in RETRYABLE_STATUSES and attempt < MAX_RETRIES - 1:
+                wait = RETRY_BACKOFF * (2**attempt)
+                print(f"  {provider} {resp.status}, retrying in {wait:.0f}s (attempt {attempt + 1}/{MAX_RETRIES})...")
+                await asyncio.sleep(wait)
+                continue
+            if resp.status != 200:
+                body = await resp.text()
+                raise Exception(f"{provider} {resp.status}: {body[:300]}")
+            return await resp.json()
+
 
 async def transcribe_deepgram(session: aiohttp.ClientSession, wav_bytes: bytes, locale: str) -> str:
     api_key = os.environ["DEEPGRAM_API_KEY"]
     dg_locale = DEEPGRAM_LOCALE_MAP.get(locale, locale)
     url = f"https://api.deepgram.com/v1/listen?model=nova-3&language={dg_locale}&punctuate=true&smart_format=false"
     headers = {"Authorization": f"Token {api_key}", "Content-Type": "audio/wav"}
-    async with session.post(url, headers=headers, data=wav_bytes) as resp:
-        if resp.status != 200:
-            body = await resp.text()
-            raise Exception(f"Deepgram {resp.status}: {body[:300]}")
-        data = await resp.json()
+    data = await _post_with_retry(session, url, headers, wav_bytes, "Deepgram")
     return data["results"]["channels"][0]["alternatives"][0]["transcript"]
 
 
@@ -333,6 +348,21 @@ async def run_transcription(args):
     locales = [args.locale] if args.locale else all_locales
 
     provider_fn = PROVIDERS[args.provider]
+
+    required_env = {
+        "deepgram-nova3": ["DEEPGRAM_API_KEY"],
+        "google-chirp3": ["GOOGLE_SPEECH_CREDENTIALS"],
+        "azure": ["AZURE_SPEECH_ENDPOINT", "AZURE_SPEECH_KEY"],
+        "elevenlabs-scribe-v2": ["ELEVENLABS_API_KEY"],
+        "openai-gpt4o-transcribe": ["OPENAI_API_KEY"],
+        "openai-gpt4o-mini-transcribe": ["OPENAI_API_KEY"],
+        "openai-gpt-audio-1.5": ["OPENAI_API_KEY"],
+    }
+    missing = [k for k in required_env.get(args.provider, []) if not os.environ.get(k)]
+    if missing:
+        print(f"ERROR: Missing required environment variables for {args.provider}: {', '.join(missing)}")
+        print("Set them in your .env file or export them before running.")
+        return
 
     print(f"Provider: {args.provider}")
     print(f"Locales: {locales}")

--- a/scripts/verify_data.py
+++ b/scripts/verify_data.py
@@ -31,7 +31,7 @@ load_dotenv()
 
 REPO_ID = "sierra-research/mu-bench"
 DURATION_TOLERANCE = 0.001  # seconds
-EXPECTED_SAMPLERATE = 24000
+EXPECTED_SAMPLERATE = 8000
 EXPECTED_CHANNELS = 1
 
 METADATA_REQUIRED_FIELDS = ("file_name", "locale", "conversation_id", "turn_index", "duration_sec", "transcript")


### PR DESCRIPTION
## Summary

Fixes items 11-20 from the OSS readiness audit (medium priority).

| # | File | Fix |
|---|------|-----|
| 11 | `scoring/llm.py` | Try plain `json.loads` before markdown fence parsing — avoids `IndexError` on unexpected formats |
| 12 | `scripts/transcribe.py` | Validate required env vars upfront with clear error instead of `KeyError` mid-run |
| 13 | `scripts/transcribe.py` | Add `_post_with_retry` helper with exponential backoff on 429/5xx |
| 14 | `scoring/validate.py` | Also validate `metadata.json` (not just `.yaml`) since `ALLOWED_ROOT_FILES` accepts both |
| 15 | `leaderboard/src/utils/metrics.js` | Quality score range "1-3" → "0-3" to match scoring rubric |
| 16 | `scoring/normalize.py` | Fix help text default dir `submissions_normalized` → `submissions/normalized` |
| 17 | `README.md` | Fix sample rate 24kHz → 8kHz |
| 18 | `.pre-commit-config.yaml` | Document leaderboard JS lint instructions |
| 19 | `README.md` | Add CI, license, and HuggingFace dataset badges |
| 20 | `scripts/verify_data.py` | Fix `EXPECTED_SAMPLERATE` from 24000 → 8000 |

## Test plan

- [ ] Verify lint passes
- [ ] Verify `validate.py` works with both `.yaml` and `.json` metadata
- [ ] Verify badges render correctly in README

Made with [Cursor](https://cursor.com)