### PR TITLE
Fix nice-to-have issues for open-source launch

### DIFF
--- a/.github/workflows/deploy-leaderboard.yml
+++ b/.github/workflows/deploy-leaderboard.yml
@@ -24,19 +24,19 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e11487 # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5 # v4
         with:
           node-version: "20"
-
-      - name: Inject leaderboard data
-        run: node leaderboard/scripts/inject-data.js
 
       - name: Install dependencies
         working-directory: leaderboard
         run: npm ci
+
+      - name: Inject leaderboard data
+        run: node leaderboard/scripts/inject-data.js
 
       - name: Build
         working-directory: leaderboard
@@ -59,10 +59,10 @@ jobs:
           REDIRECT
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609 # v3
         with:
           path: site
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db9016 # v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
   python:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e11487 # v4
 
       - name: Install ruff
         run: pip install ruff
@@ -24,10 +24,10 @@ jobs:
   javascript:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e11487 # v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5 # v4
         with:
           node-version: "20"
 

--- a/.github/workflows/post-merge-score.yml
+++ b/.github/workflows/post-merge-score.yml
@@ -9,13 +9,17 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: post-merge-score
+  cancel-in-progress: false
+
 jobs:
   score-and-commit:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     environment: scoring
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e11487 # v4
         with:
           ref: main
           fetch-depth: 0
@@ -23,13 +27,21 @@ jobs:
       - name: Detect and validate submission directory name
         id: detect
         run: |
-          MERGE_SHA=$(git log -1 --format='%H')
-          CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD -- submissions/raw/)
-          SUBMISSION_DIR=$(echo "$CHANGED_FILES" | sed 's|^\(submissions/raw/[^/]*\)/.*|\1|' | sort -u | head -1)
-          if [ -z "$SUBMISSION_DIR" ]; then
+          MERGE_SHA=${{ github.event.pull_request.merge_commit_sha }}
+          echo "Merge commit: $MERGE_SHA"
+          CHANGED_FILES=$(git diff --name-only "${MERGE_SHA}^1" "${MERGE_SHA}" -- submissions/raw/)
+          DIRS=$(echo "$CHANGED_FILES" | sed 's|^\(submissions/raw/[^/]*\)/.*|\1|' | sort -u)
+          if [ -z "$DIRS" ]; then
             echo "No submission directory detected"
             exit 1
           fi
+          DIR_COUNT=$(echo "$DIRS" | wc -l | tr -d ' ')
+          if [ "$DIR_COUNT" -gt 1 ]; then
+            echo "ERROR: Multiple submission directories detected. PRs should contain exactly one submission."
+            echo "$DIRS"
+            exit 1
+          fi
+          SUBMISSION_DIR=$(echo "$DIRS" | head -1)
           SUBMISSION_NAME=$(basename "$SUBMISSION_DIR")
           if ! echo "$SUBMISSION_NAME" | grep -qE '^[a-zA-Z0-9_-]+$'; then
             echo "ERROR: Submission directory name contains disallowed characters: $SUBMISSION_NAME"
@@ -37,10 +49,10 @@ jobs:
           fi
           echo "dir=$SUBMISSION_DIR" >> "$GITHUB_OUTPUT"
           echo "name=$SUBMISSION_NAME" >> "$GITHUB_OUTPUT"
-          echo "Detected submission: $SUBMISSION_DIR (merge commit: $MERGE_SHA)"
+          echo "Detected submission: $SUBMISSION_DIR"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69b # v5
         with:
           python-version: "3.12"
 

--- a/.github/workflows/score-submission.yml
+++ b/.github/workflows/score-submission.yml
@@ -5,7 +5,7 @@ on:
     types: [created]
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 
 concurrency:
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Decide whether to score
         id: decide
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7 # v7
         with:
           script: |
             const comment = context.payload.comment;
@@ -78,7 +78,7 @@ jobs:
     steps:
       # SECURITY: Always checkout main for scoring code — never run PR code with secrets
       - name: Checkout base branch (scoring code)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e11487 # v4
         with:
           ref: main
           fetch-depth: 0
@@ -93,11 +93,18 @@ jobs:
         id: detect
         run: |
           CHANGED_FILES=$(git diff --name-only HEAD -- submissions/raw/)
-          SUBMISSION_DIR=$(echo "$CHANGED_FILES" | sed 's|^\(submissions/raw/[^/]*\)/.*|\1|' | sort -u | head -1)
-          if [ -z "$SUBMISSION_DIR" ]; then
+          DIRS=$(echo "$CHANGED_FILES" | sed 's|^\(submissions/raw/[^/]*\)/.*|\1|' | sort -u)
+          if [ -z "$DIRS" ]; then
             echo "No submission directory detected"
             exit 1
           fi
+          DIR_COUNT=$(echo "$DIRS" | wc -l | tr -d ' ')
+          if [ "$DIR_COUNT" -gt 1 ]; then
+            echo "ERROR: Multiple submission directories detected. Please submit one model per PR."
+            echo "$DIRS"
+            exit 1
+          fi
+          SUBMISSION_DIR=$(echo "$DIRS" | head -1)
           SUBMISSION_NAME=$(basename "$SUBMISSION_DIR")
           if ! echo "$SUBMISSION_NAME" | grep -qE '^[a-zA-Z0-9_-]+$'; then
             echo "ERROR: Submission directory name contains disallowed characters: $SUBMISSION_NAME"
@@ -109,7 +116,7 @@ jobs:
           echo "Detected submission: $SUBMISSION_DIR"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69b # v5
         with:
           python-version: "3.12"
 
@@ -122,7 +129,7 @@ jobs:
 
       - name: Post "scoring in progress" comment
         id: progress
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7 # v7
         with:
           script: |
             const { data: comment } = await github.rest.issues.createComment({
@@ -168,7 +175,7 @@ jobs:
 
       - name: Post results comment
         if: always() && steps.progress.outputs.comment_id
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7 # v7
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/validate-submission.yml
+++ b/.github/workflows/validate-submission.yml
@@ -13,12 +13,12 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e11487 # v4
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69b # v5
         with:
           python-version: "3.12"
 
@@ -29,12 +29,18 @@ jobs:
         id: detect
         run: |
           CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} HEAD -- submissions/raw/)
-          # Extract the submission dir (submissions/raw/<model-name>)
-          SUBMISSION_DIR=$(echo "$CHANGED_FILES" | sed 's|^\(submissions/raw/[^/]*\)/.*|\1|' | sort -u | head -1)
-          if [ -z "$SUBMISSION_DIR" ]; then
+          DIRS=$(echo "$CHANGED_FILES" | sed 's|^\(submissions/raw/[^/]*\)/.*|\1|' | sort -u)
+          if [ -z "$DIRS" ]; then
             echo "No submission directory detected from changed files"
             exit 1
           fi
+          DIR_COUNT=$(echo "$DIRS" | wc -l | tr -d ' ')
+          if [ "$DIR_COUNT" -gt 1 ]; then
+            echo "ERROR: Multiple submission directories detected. Please submit one model per PR."
+            echo "$DIRS"
+            exit 1
+          fi
+          SUBMISSION_DIR=$(echo "$DIRS" | head -1)
           echo "dir=$SUBMISSION_DIR" >> "$GITHUB_OUTPUT"
           echo "Detected submission: $SUBMISSION_DIR"
 
@@ -46,7 +52,7 @@ jobs:
 
       - name: Comment on PR
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7 # v7
         with:
           script: |
             const fs = require('fs');

--- a/leaderboard/src/components/Leaderboard.css
+++ b/leaderboard/src/components/Leaderboard.css
@@ -480,6 +480,10 @@
     cursor: pointer;
     user-select: none;
     padding: 4px 0;
+    background: none;
+    border: none;
+    font: inherit;
+    color: inherit;
 }
 
 .collapsible-toggle:hover .collapsible-label {

--- a/leaderboard/src/components/Leaderboard.jsx
+++ b/leaderboard/src/components/Leaderboard.jsx
@@ -321,7 +321,7 @@ export default function Leaderboard() {
 
 function ProviderRow({ provider, sigWerMetric, latencyMetric, onRowClick }) {
     return (
-        <tr className="provider-row" onClick={onRowClick}>
+        <tr className="provider-row" onClick={onRowClick} onKeyDown={(e) => e.key === "Enter" && onRowClick()} tabIndex={0} role="button">
             <td className="col-rank">
                 <span
                     className={`rank-number ${provider.rank === 1 ? "rank-gold" : provider.rank === 2 ? "rank-silver" : provider.rank === 3 ? "rank-bronze" : ""}`}
@@ -384,10 +384,10 @@ function ProviderDetailOverall({ provider, providerId }) {
     return (
         <div className="provider-detail-sections">
             <div className="collapsible-section">
-                <div className="collapsible-toggle" onClick={() => setShowScores(!showScores)}>
+                <button type="button" className="collapsible-toggle" onClick={() => setShowScores(!showScores)} aria-expanded={showScores}>
                     <span className={`collapsible-caret ${showScores ? "open" : ""}`}>{"\u25B6"}</span>
                     <span className="collapsible-label">Metrics by Locale</span>
-                </div>
+                </button>
                 {showScores && (
                     <div className="collapsible-content">
                         <table className="scores-table">
@@ -419,10 +419,10 @@ function ProviderDetailOverall({ provider, providerId }) {
             </div>
 
             <div className="collapsible-section">
-                <div className="collapsible-toggle" onClick={() => setShowUtterances(!showUtterances)}>
+                <button type="button" className="collapsible-toggle" onClick={() => setShowUtterances(!showUtterances)} aria-expanded={showUtterances}>
                     <span className={`collapsible-caret ${showUtterances ? "open" : ""}`}>{"\u25B6"}</span>
                     <span className="collapsible-label">Compare transcripts to ground truth</span>
-                </div>
+                </button>
                 {showUtterances && (
                     <div className="collapsible-content">
                         <table className="utterance-table">

--- a/scoring/update_leaderboard.py
+++ b/scoring/update_leaderboard.py
@@ -55,6 +55,9 @@ def main():
         info = LOCALE_LABELS.get(code, {"label": code, "flag": ""})
         locales.append({"code": code, "label": info["label"], "flag": info["flag"]})
 
+    if not providers:
+        print("WARNING: No providers found in results/*/scores.json — leaderboard will be empty")
+
     leaderboard = {"locales": locales, "providers": providers}
 
     output_path = results_dir / "leaderboard.json"


### PR DESCRIPTION
## Summary

Fixes the remaining low-priority items from the OSS readiness audit.

### Supply-chain security
- Pin all GitHub Actions to commit SHAs instead of mutable `@v4` tags (all 5 workflows)

### CI robustness
- **post-merge-score.yml**: Use `merge_commit_sha` from the event payload and diff against first parent — fixes brittle `HEAD~1` detection
- **All 3 submission workflows**: Reject PRs that touch multiple submission directories instead of silently picking the first one

### Leaderboard accessibility
- Table rows: added `tabIndex={0}`, `role="button"`, and Enter key handler for keyboard navigation
- Collapsible toggles: changed from `<div>` to `<button>` with `aria-expanded` attribute
- Reset default button styles in CSS

### update_leaderboard.py
- Warn when no providers found (empty leaderboard)

## Test plan
- [ ] Verify CI workflows still trigger correctly with pinned SHAs
- [ ] Test keyboard navigation on leaderboard table rows (Tab + Enter)
- [ ] Test collapsible sections are keyboard-accessible

Made with [Cursor](https://cursor.com)