### PR TITLE
Update GPT-4o Mini Transcribe with c1 latency

### DIFF
--- a/leaderboard/src/data/data.js
+++ b/leaderboard/src/data/data.js
@@ -2,633 +2,586 @@
 
 export const LOCALES = [
     {
-        code: "en-US",
-        label: "English (US)",
-        flag: "🇺🇸",
+        "code": "en-US",
+        "label": "English (US)",
+        "flag": "🇺🇸"
     },
     {
-        code: "es-MX",
-        label: "Spanish (MX)",
-        flag: "🇲🇽",
+        "code": "es-MX",
+        "label": "Spanish (MX)",
+        "flag": "🇲🇽"
     },
     {
-        code: "tr-TR",
-        label: "Turkish",
-        flag: "🇹🇷",
+        "code": "tr-TR",
+        "label": "Turkish",
+        "flag": "🇹🇷"
     },
     {
-        code: "vi-VN",
-        label: "Vietnamese",
-        flag: "🇻🇳",
+        "code": "vi-VN",
+        "label": "Vietnamese",
+        "flag": "🇻🇳"
     },
     {
-        code: "zh-CN",
-        label: "Chinese (CN)",
-        flag: "🇨🇳",
-    },
+        "code": "zh-CN",
+        "label": "Chinese (CN)",
+        "flag": "🇨🇳"
+    }
 ];
 
 export const PROVIDERS = [
     {
-        id: "azure",
-        model: "Azure-Speech-v1",
-        organization: "Microsoft",
-        modelDate: "2026-04-14",
-        localeResults: {
+        "id": "azure",
+        "model": "Azure-Speech-v1",
+        "organization": "Microsoft",
+        "modelDate": "2026-04-14",
+        "localeResults": {
             "en-US": {
-                wer: 0.0372,
-                significantWer: 0.0334,
-                qualityScore: null,
-                latencyP50Ms: 276.5,
-                latencyP95Ms: 639.9,
+                "wer": 0.0372,
+                "significantWer": 0.0334,
+                "qualityScore": null,
+                "latencyP50Ms": 276.5,
+                "latencyP95Ms": 639.9
             },
             "es-MX": {
-                wer: 0.1082,
-                significantWer: 0.1288,
-                qualityScore: null,
-                latencyP50Ms: 242.8,
-                latencyP95Ms: 475.9,
+                "wer": 0.1082,
+                "significantWer": 0.1288,
+                "qualityScore": null,
+                "latencyP50Ms": 242.8,
+                "latencyP95Ms": 475.9
             },
             "tr-TR": {
-                wer: 0.0993,
-                significantWer: 0.2506,
-                qualityScore: null,
-                latencyP50Ms: 967.7,
-                latencyP95Ms: 1815.1,
+                "wer": 0.0993,
+                "significantWer": 0.2506,
+                "qualityScore": null,
+                "latencyP50Ms": 967.7,
+                "latencyP95Ms": 1815.1
             },
             "vi-VN": {
-                wer: 0.1845,
-                significantWer: 0.3029,
-                qualityScore: null,
-                latencyP50Ms: 276.9,
-                latencyP95Ms: 586.3,
+                "wer": 0.1845,
+                "significantWer": 0.3029,
+                "qualityScore": null,
+                "latencyP50Ms": 276.9,
+                "latencyP95Ms": 586.3
             },
             "zh-CN": {
-                wer: 0.1789,
-                significantWer: 0.2524,
-                qualityScore: null,
-                latencyP50Ms: 262.8,
-                latencyP95Ms: 423.7,
-            },
-        },
+                "wer": 0.1789,
+                "significantWer": 0.2524,
+                "qualityScore": null,
+                "latencyP50Ms": 262.8,
+                "latencyP95Ms": 423.7
+            }
+        }
     },
     {
-        id: "deepgram-nova3",
-        model: "Nova-3",
-        organization: "Deepgram",
-        modelDate: "2026-04-14",
-        localeResults: {
+        "id": "deepgram-nova3",
+        "model": "Nova-3",
+        "organization": "Deepgram",
+        "modelDate": "2026-04-14",
+        "localeResults": {
             "en-US": {
-                wer: 0.0408,
-                significantWer: 0.052,
-                qualityScore: null,
-                latencyP50Ms: 245.7,
-                latencyP95Ms: 617.9,
+                "wer": 0.0408,
+                "significantWer": 0.052,
+                "qualityScore": null,
+                "latencyP50Ms": 245.7,
+                "latencyP95Ms": 617.9
             },
             "es-MX": {
-                wer: 0.0792,
-                significantWer: 0.1503,
-                qualityScore: null,
-                latencyP50Ms: 282,
-                latencyP95Ms: 632.6,
+                "wer": 0.0792,
+                "significantWer": 0.1503,
+                "qualityScore": null,
+                "latencyP50Ms": 282,
+                "latencyP95Ms": 632.6
             },
             "tr-TR": {
-                wer: 0.1011,
-                significantWer: 0.1939,
-                qualityScore: null,
-                latencyP50Ms: 238.9,
-                latencyP95Ms: 660.3,
+                "wer": 0.1011,
+                "significantWer": 0.1939,
+                "qualityScore": null,
+                "latencyP50Ms": 238.9,
+                "latencyP95Ms": 660.3
             },
             "vi-VN": {
-                wer: 0.3931,
-                significantWer: 0.5415,
-                qualityScore: null,
-                latencyP50Ms: 235.2,
-                latencyP95Ms: 755.3,
+                "wer": 0.3931,
+                "significantWer": 0.5415,
+                "qualityScore": null,
+                "latencyP50Ms": 235.2,
+                "latencyP95Ms": 755.3
             },
             "zh-CN": {
-                wer: 0.194,
-                significantWer: 0.2897,
-                qualityScore: null,
-                latencyP50Ms: 192.9,
-                latencyP95Ms: 1137.3,
-            },
-        },
+                "wer": 0.194,
+                "significantWer": 0.2897,
+                "qualityScore": null,
+                "latencyP50Ms": 192.9,
+                "latencyP95Ms": 1137.3
+            }
+        }
     },
     {
-        id: "elevenlabs-scribe-v2",
-        model: "Scribe-v2",
-        organization: "ElevenLabs",
-        modelDate: "2026-04-14",
-        localeResults: {
+        "id": "elevenlabs-scribe-v2",
+        "model": "Scribe-v2",
+        "organization": "ElevenLabs",
+        "modelDate": "2026-04-14",
+        "localeResults": {
             "en-US": {
-                wer: 0.0665,
-                significantWer: 0.0644,
-                qualityScore: null,
-                latencyP50Ms: 430,
-                latencyP95Ms: 890,
+                "wer": 0.0665,
+                "significantWer": 0.0644,
+                "qualityScore": null,
+                "latencyP50Ms": 430,
+                "latencyP95Ms": 890
             },
             "es-MX": {
-                wer: 0.1126,
-                significantWer: 0.1149,
-                qualityScore: null,
-                latencyP50Ms: 429.3,
-                latencyP95Ms: 828.1,
+                "wer": 0.1126,
+                "significantWer": 0.1149,
+                "qualityScore": null,
+                "latencyP50Ms": 429.3,
+                "latencyP95Ms": 828.1
             },
             "tr-TR": {
-                wer: 0.0969,
-                significantWer: 0.1253,
-                qualityScore: null,
-                latencyP50Ms: 455.6,
-                latencyP95Ms: 902.6,
+                "wer": 0.0969,
+                "significantWer": 0.1253,
+                "qualityScore": null,
+                "latencyP50Ms": 455.6,
+                "latencyP95Ms": 902.6
             },
             "vi-VN": {
-                wer: 0.2133,
-                significantWer: 0.2577,
-                qualityScore: null,
-                latencyP50Ms: 432.3,
-                latencyP95Ms: 821,
+                "wer": 0.2133,
+                "significantWer": 0.2577,
+                "qualityScore": null,
+                "latencyP50Ms": 432.3,
+                "latencyP95Ms": 821
             },
             "zh-CN": {
-                wer: 0.1626,
-                significantWer: 0.2337,
-                qualityScore: null,
-                latencyP50Ms: 375.6,
-                latencyP95Ms: 559.9,
-            },
-        },
+                "wer": 0.1626,
+                "significantWer": 0.2337,
+                "qualityScore": null,
+                "latencyP50Ms": 375.6,
+                "latencyP95Ms": 559.9
+            }
+        }
     },
     {
-        id: "google-chirp3",
-        model: "Chirp-3",
-        organization: "Google",
-        modelDate: "2026-04-14",
-        localeResults: {
+        "id": "google-chirp3",
+        "model": "Chirp-3",
+        "organization": "Google",
+        "modelDate": "2026-04-14",
+        "localeResults": {
             "en-US": {
-                wer: 0.0438,
-                significantWer: 0.0509,
-                qualityScore: null,
-                latencyP50Ms: 1235.8,
-                latencyP95Ms: 2145.7,
+                "wer": 0.0438,
+                "significantWer": 0.0509,
+                "qualityScore": null,
+                "latencyP50Ms": 1235.8,
+                "latencyP95Ms": 2145.7
             },
             "es-MX": {
-                wer: 0.0739,
-                significantWer: 0.101,
-                qualityScore: null,
-                latencyP50Ms: 1192.3,
-                latencyP95Ms: 1975.2,
+                "wer": 0.0739,
+                "significantWer": 0.101,
+                "qualityScore": null,
+                "latencyP50Ms": 1192.3,
+                "latencyP95Ms": 1975.2
             },
             "tr-TR": {
-                wer: 0.0631,
-                significantWer: 0.0981,
-                qualityScore: null,
-                latencyP50Ms: 1239.8,
-                latencyP95Ms: 2027.9,
+                "wer": 0.0631,
+                "significantWer": 0.0981,
+                "qualityScore": null,
+                "latencyP50Ms": 1239.8,
+                "latencyP95Ms": 2027.9
             },
             "vi-VN": {
-                wer: 0.0731,
-                significantWer: 0.1078,
-                qualityScore: null,
-                latencyP50Ms: 1253.7,
-                latencyP95Ms: 2165,
+                "wer": 0.0731,
+                "significantWer": 0.1078,
+                "qualityScore": null,
+                "latencyP50Ms": 1253.7,
+                "latencyP95Ms": 2165
             },
             "zh-CN": {
-                wer: 0.0883,
-                significantWer: 0.1645,
-                qualityScore: null,
-                latencyP50Ms: 1140.3,
-                latencyP95Ms: 1715.4,
-            },
-        },
+                "wer": 0.0883,
+                "significantWer": 0.1645,
+                "qualityScore": null,
+                "latencyP50Ms": 1140.3,
+                "latencyP95Ms": 1715.4
+            }
+        }
     },
     {
-        id: "openai-gpt4o-mini-transcribe",
-        model: "GPT-4o-Mini-Transcribe",
-        organization: "OpenAI",
-        modelDate: "2026-04-15",
-        localeResults: {
+        "id": "openai-gpt4o-mini-transcribe",
+        "model": "GPT-4o-Mini-Transcribe",
+        "organization": "OpenAI",
+        "modelDate": "2026-04-15",
+        "localeResults": {
             "en-US": {
-                wer: 0.0391,
-                significantWer: 0.0484,
-                qualityScore: null,
-                latencyP50Ms: 663.7,
-                latencyP95Ms: 1327.7,
+                "wer": 0.0391,
+                "significantWer": 0.0484,
+                "qualityScore": null,
+                "latencyP50Ms": 616.9,
+                "latencyP95Ms": 1091.9
             },
             "es-MX": {
-                wer: 0.1113,
-                significantWer: 0.1465,
-                qualityScore: null,
-                latencyP50Ms: 659,
-                latencyP95Ms: 1375.4,
+                "wer": 0.1113,
+                "significantWer": 0.1465,
+                "qualityScore": null,
+                "latencyP50Ms": 676.7,
+                "latencyP95Ms": 1215.8
             },
             "tr-TR": {
-                wer: 0.1133,
-                significantWer: 0.1856,
-                qualityScore: null,
-                latencyP50Ms: 696.2,
-                latencyP95Ms: 1652,
+                "wer": 0.1133,
+                "significantWer": 0.1856,
+                "qualityScore": null,
+                "latencyP50Ms": 731.4,
+                "latencyP95Ms": 1337.1
             },
             "vi-VN": {
-                wer: 0.209,
-                significantWer: 0.3203,
-                qualityScore: null,
-                latencyP50Ms: 661.8,
-                latencyP95Ms: 1281.2,
+                "wer": 0.209,
+                "significantWer": 0.3203,
+                "qualityScore": null,
+                "latencyP50Ms": 691.3,
+                "latencyP95Ms": 1340.3
             },
             "zh-CN": {
-                wer: 0.1596,
-                significantWer: 0.2137,
-                qualityScore: null,
-                latencyP50Ms: 566,
-                latencyP95Ms: 1116.1,
-            },
-        },
-    },
+                "wer": 0.1596,
+                "significantWer": 0.2137,
+                "qualityScore": null,
+                "latencyP50Ms": 620.5,
+                "latencyP95Ms": 1248.8
+            }
+        }
+    }
 ];
 
 export const SAMPLE_UTTERANCES = {
     "en-US": [
         {
-            id: "conv-39-turn-8",
-            locale: "en-US",
-            transcript: "It'd be under my name, Ashley Brown. And do you want my email address?",
-            hasAudio: true,
-            submissions: {
-                azure: "it will be under my name ashley brown and do you want my email address",
+            "id": "conv-39-turn-8",
+            "locale": "en-US",
+            "transcript": "It'd be under my name, Ashley Brown. And do you want my email address?",
+            "hasAudio": true,
+            "submissions": {
+                "azure": "it will be under my name ashley brown and do you want my email address",
                 "deepgram-nova3": "it will it will be under my name ashley brown and do you want my email address",
-                "elevenlabs-scribe-v2":
-                    "it will it will be under my name ashley brown and do you want my email address",
+                "elevenlabs-scribe-v2": "it will it will be under my name ashley brown and do you want my email address",
                 "google-chirp3": "it would be under my name ashley brown and do you want my email address",
-                "openai-gpt4o-mini-transcribe":
-                    "it will be under my name ashley brown and do you want my email address",
-            },
+                "openai-gpt4o-mini-transcribe": "it will be under my name ashley brown and do you want my email address"
+            }
         },
         {
-            id: "conv-48-turn-3",
-            locale: "en-US",
-            transcript: "Let me confirm that code. I have C as in cat, N as in Nancy, 6 2 2 6 2 0 6.",
-            hasAudio: false,
-            submissions: {
-                azure: "let me confirm that code i have c as in cat n as in nancy six two two six two zero six",
-                "deepgram-nova3":
-                    "let me confirm that code i have c as in cat n as in nancy six two two six two zero six",
-                "elevenlabs-scribe-v2":
-                    "let me confirm that code i have steven kat and as in nancy six two two six two zero six",
-                "google-chirp3":
-                    "let me confirm that code i have c as in cat n as in nancy six two two six two zero six",
-                "openai-gpt4o-mini-transcribe":
-                    "let me confirm that code i have c as in cat n as in nancy six two two six two zero six",
-            },
+            "id": "conv-48-turn-3",
+            "locale": "en-US",
+            "transcript": "Let me confirm that code. I have C as in cat, N as in Nancy, 6 2 2 6 2 0 6.",
+            "hasAudio": false,
+            "submissions": {
+                "azure": "let me confirm that code i have c as in cat n as in nancy six two two six two zero six",
+                "deepgram-nova3": "let me confirm that code i have c as in cat n as in nancy six two two six two zero six",
+                "elevenlabs-scribe-v2": "let me confirm that code i have steven kat and as in nancy six two two six two zero six",
+                "google-chirp3": "let me confirm that code i have c as in cat n as in nancy six two two six two zero six",
+                "openai-gpt4o-mini-transcribe": "let me confirm that code i have c as in cat n as in nancy six two two six two zero six"
+            }
         },
         {
-            id: "conv-14-turn-11",
-            locale: "en-US",
-            transcript: "Email address should be John dot Brown at email dot com.",
-            hasAudio: false,
-            submissions: {
-                azure: "email address would be john dot brown at email dot com",
+            "id": "conv-14-turn-11",
+            "locale": "en-US",
+            "transcript": "Email address should be John dot Brown at email dot com.",
+            "hasAudio": false,
+            "submissions": {
+                "azure": "email address would be john dot brown at email dot com",
                 "deepgram-nova3": "email address would be john dot brown at email dot com",
                 "elevenlabs-scribe-v2": "email address would be john dot brown at email dot com",
                 "google-chirp3": "email address would be john dot brown at email dot com",
-                "openai-gpt4o-mini-transcribe": "email address would be john dot brown at email dot com",
-            },
+                "openai-gpt4o-mini-transcribe": "email address would be john dot brown at email dot com"
+            }
         },
         {
-            id: "conv-0-turn-9",
-            locale: "en-US",
-            transcript: "Um.",
-            hasAudio: false,
-            submissions: {
-                azure: "",
+            "id": "conv-0-turn-9",
+            "locale": "en-US",
+            "transcript": "Um.",
+            "hasAudio": false,
+            "submissions": {
+                "azure": "",
                 "deepgram-nova3": "",
                 "elevenlabs-scribe-v2": "",
                 "google-chirp3": "",
-                "openai-gpt4o-mini-transcribe": "",
-            },
+                "openai-gpt4o-mini-transcribe": ""
+            }
         },
         {
-            id: "conv-17-turn-4",
-            locale: "en-US",
-            transcript:
-                "Okay. Hopefully, I get all that information for you. Let's see here. My full name for this account would be John Brown.",
-            hasAudio: false,
-            submissions: {
-                azure: "okay hopefully i got all that information for you let us see here my full name for this account would be john brown",
-                "deepgram-nova3":
-                    "okay hopefully i got all that information for you let us see here my full name for this account would be john brown",
-                "elevenlabs-scribe-v2":
-                    "okay hopefully i got all that information for you let us see here my full name for this account would be john brown",
-                "google-chirp3":
-                    "okay hopefully i got all that information for you let us see here my full name for this account would be john brown",
-                "openai-gpt4o-mini-transcribe":
-                    "okay hopefully i got all that information for you let us see here my full name for this account would be john brown",
-            },
-        },
+            "id": "conv-17-turn-4",
+            "locale": "en-US",
+            "transcript": "Okay. Hopefully, I get all that information for you. Let's see here. My full name for this account would be John Brown.",
+            "hasAudio": false,
+            "submissions": {
+                "azure": "okay hopefully i got all that information for you let us see here my full name for this account would be john brown",
+                "deepgram-nova3": "okay hopefully i got all that information for you let us see here my full name for this account would be john brown",
+                "elevenlabs-scribe-v2": "okay hopefully i got all that information for you let us see here my full name for this account would be john brown",
+                "google-chirp3": "okay hopefully i got all that information for you let us see here my full name for this account would be john brown",
+                "openai-gpt4o-mini-transcribe": "okay hopefully i got all that information for you let us see here my full name for this account would be john brown"
+            }
+        }
     ],
     "es-MX": [
         {
-            id: "conv-49-turn-5",
-            locale: "es-MX",
-            transcript: "Es Juan punto López arroba email punto com.",
-            hasAudio: true,
-            submissions: {
-                azure: "no es juan punto lopez arroba email punto com",
+            "id": "conv-49-turn-5",
+            "locale": "es-MX",
+            "transcript": "Es Juan punto López arroba email punto com.",
+            "hasAudio": true,
+            "submissions": {
+                "azure": "no es juan punto lopez arroba email punto com",
                 "deepgram-nova3": "es juan punto lopez arroba email punto com",
                 "elevenlabs-scribe-v2": "es juan punto lopez arroba email punto com",
                 "google-chirp3": "es no es juan punto lopez arroba email punto com",
-                "openai-gpt4o-mini-transcribe": "es juan punto lopez arroba email punto com",
-            },
+                "openai-gpt4o-mini-transcribe": "es juan punto lopez arroba email punto com"
+            }
         },
         {
-            id: "conv-2-turn-1",
-            locale: "es-MX",
-            transcript: "Serían C N 9 2 4.",
-            hasAudio: false,
-            submissions: {
-                azure: "seria es c n nueve dos cuatro",
+            "id": "conv-2-turn-1",
+            "locale": "es-MX",
+            "transcript": "Serían C N 9 2 4.",
+            "hasAudio": false,
+            "submissions": {
+                "azure": "seria es c n nueve dos cuatro",
                 "deepgram-nova3": "seria e c n nueve dos cuatro",
                 "elevenlabs-scribe-v2": "seria f c n nueve dos cuatro",
                 "google-chirp3": "seria c n nueve dos cuatro",
-                "openai-gpt4o-mini-transcribe": "seria e c n nueve dos cuatro",
-            },
+                "openai-gpt4o-mini-transcribe": "seria e c n nueve dos cuatro"
+            }
         },
         {
-            id: "conv-47-turn-1",
-            locale: "es-MX",
-            transcript:
-                "Mi nombre es Juan López. Mi correo electrónico es Juan punto López arroba email punto com. Mi teléfono es 52 55 1 2 3 4 5 6 7 8. Mi dirección es Urión 30, Colonia Tlatilco, Azcapotzalco, 0 2 0 0 2 8 60, Ciudad de México, México.",
-            hasAudio: false,
-            submissions: {
-                azure: "mi nombre es juan lopez mi correo electronico es juan punto lopez arroba email punto com mi numero de telefono es cincuenta y dos cincuenta y cinco uno dos tres cuatro cinco seis siete ocho mi direccion es orion treinta colonia tlatilco azcapotzalco cero dos cero cero dos ocho sesenta ciudad de mexico mexico",
-                "deepgram-nova3":
-                    "mi nombre es juan lopez mi correo electronico es juan punto lopez arroba gmail punto com mi numero de telefono es cincuenta y dos cincuenta y cinco uno dos tres cuatro cinco seis siete ocho mi direccion es union treinta colonia tlatilco azcapotzalco cero dos cero cero dos ocho sesenta ciudad de mexico mexico",
-                "elevenlabs-scribe-v2":
-                    "mi nombre es juan lopez mi correo electronico es juan punto lopez arroba gmail punto com mi numero de telefono es cincuenta y dos cincuenta y cinco uno dos tres cuatro cinco seis siete ocho mi direccion es orion treinta colonia tlatilco azcapotzalco cero dos cero cero dos ocho sesenta ciudad de mexico mexico",
-                "google-chirp3":
-                    "mi nombre es juan lopez mi correo electronico es juan punto lopez arroba email punto com mi numero de telefono es cincuenta y dos cincuenta y cinco uno dos tres cuatro cinco seis siete ocho mi direccion es orion treinta colonia tlatilco azcapotzalco cero dos cero cero dos ocho sesenta ciudad de mexico mexico",
-                "openai-gpt4o-mini-transcribe":
-                    "mi nombre es juan lopez mi correo electronico es juan punto lopez arroba email punto com mi numero de telefono es cincuenta y dos cincuenta y cinco uno dos tres cuatro cinco seis siete ocho mi direccion es urion treinta colonia tlaltenco azcapotzalco cero dos cero cero dos ochocientos sesenta ciudad de mexico mexico",
-            },
+            "id": "conv-47-turn-1",
+            "locale": "es-MX",
+            "transcript": "Mi nombre es Juan López. Mi correo electrónico es Juan punto López arroba email punto com. Mi teléfono es 52 55 1 2 3 4 5 6 7 8. Mi dirección es Urión 30, Colonia Tlatilco, Azcapotzalco, 0 2 0 0 2 8 60, Ciudad de México, México.",
+            "hasAudio": false,
+            "submissions": {
+                "azure": "mi nombre es juan lopez mi correo electronico es juan punto lopez arroba email punto com mi numero de telefono es cincuenta y dos cincuenta y cinco uno dos tres cuatro cinco seis siete ocho mi direccion es orion treinta colonia tlatilco azcapotzalco cero dos cero cero dos ocho sesenta ciudad de mexico mexico",
+                "deepgram-nova3": "mi nombre es juan lopez mi correo electronico es juan punto lopez arroba gmail punto com mi numero de telefono es cincuenta y dos cincuenta y cinco uno dos tres cuatro cinco seis siete ocho mi direccion es union treinta colonia tlatilco azcapotzalco cero dos cero cero dos ocho sesenta ciudad de mexico mexico",
+                "elevenlabs-scribe-v2": "mi nombre es juan lopez mi correo electronico es juan punto lopez arroba gmail punto com mi numero de telefono es cincuenta y dos cincuenta y cinco uno dos tres cuatro cinco seis siete ocho mi direccion es orion treinta colonia tlatilco azcapotzalco cero dos cero cero dos ocho sesenta ciudad de mexico mexico",
+                "google-chirp3": "mi nombre es juan lopez mi correo electronico es juan punto lopez arroba email punto com mi numero de telefono es cincuenta y dos cincuenta y cinco uno dos tres cuatro cinco seis siete ocho mi direccion es orion treinta colonia tlatilco azcapotzalco cero dos cero cero dos ocho sesenta ciudad de mexico mexico",
+                "openai-gpt4o-mini-transcribe": "mi nombre es juan lopez mi correo electronico es juan punto lopez arroba email punto com mi numero de telefono es cincuenta y dos cincuenta y cinco uno dos tres cuatro cinco seis siete ocho mi direccion es urion treinta colonia tlaltenco azcapotzalco cero dos cero cero dos ochocientos sesenta ciudad de mexico mexico"
+            }
         },
         {
-            id: "conv-29-turn-11",
-            locale: "es-MX",
-            transcript:
-                "Es Urión, 30 Colonia Tlatilco, Delegación Azcapotzalco, en la Ciudad de México. Código postal 0 2 860.",
-            hasAudio: false,
-            submissions: {
-                azure: "es urion treinta colonia atlatilco delegacion azcapotzalco en la ciudad de mexico codigo postal cero dos ocho seis cero",
-                "deepgram-nova3":
-                    "es urion treinta colonia atlatico delegacion azcapotzalco en la ciudad de mexico codigo postal cero dos ochocientos sesenta",
-                "elevenlabs-scribe-v2":
-                    "es urion treinta colonia tlatilco delegacion azcapotzalco en la ciudad de mexico codigo postal cero dos ochocientos sesenta",
-                "google-chirp3":
-                    "escurion treinta colonia atlantico delegacion azcapotzalco en la ciudad de mexico codigo postal cero dos ocho seis cero",
-                "openai-gpt4o-mini-transcribe":
-                    "isurion treinta colonia atlantico delegacion azcapotzalco en la ciudad de mexico codigo postal cero dos ochocientos sesenta",
-            },
+            "id": "conv-29-turn-11",
+            "locale": "es-MX",
+            "transcript": "Es Urión, 30 Colonia Tlatilco, Delegación Azcapotzalco, en la Ciudad de México. Código postal 0 2 860.",
+            "hasAudio": false,
+            "submissions": {
+                "azure": "es urion treinta colonia atlatilco delegacion azcapotzalco en la ciudad de mexico codigo postal cero dos ocho seis cero",
+                "deepgram-nova3": "es urion treinta colonia atlatico delegacion azcapotzalco en la ciudad de mexico codigo postal cero dos ochocientos sesenta",
+                "elevenlabs-scribe-v2": "es urion treinta colonia tlatilco delegacion azcapotzalco en la ciudad de mexico codigo postal cero dos ochocientos sesenta",
+                "google-chirp3": "escurion treinta colonia atlantico delegacion azcapotzalco en la ciudad de mexico codigo postal cero dos ocho seis cero",
+                "openai-gpt4o-mini-transcribe": "isurion treinta colonia atlantico delegacion azcapotzalco en la ciudad de mexico codigo postal cero dos ochocientos sesenta"
+            }
         },
         {
-            id: "conv-14-turn-15",
-            locale: "es-MX",
-            transcript:
-                "Es, el monto es de 3200 pesos. Pues la fecha es de ayer en la noche y el destinatario pues es una cuenta particular, no, no sé cuál es.",
-            hasAudio: false,
-            submissions: {
-                azure: "este el monto es de tres mil doscientos pesos pues la fecha es de ayer en la noche y el destinatario pues es una cuenta particular no se cual es",
-                "deepgram-nova3":
-                    "este el monto es de tres mil doscientos pesos pues la fecha es de ayer en la noche y el destinatario pues es una cuenta particular no no se cual es",
-                "elevenlabs-scribe-v2":
-                    "este el monto es de tres mil doscientos pesos pues la fecha es de ayer en la noche y el destinatario pues es una cuenta particular no no se cual es",
-                "google-chirp3":
-                    "este el monto es de tres mil doscientos pesos pues la fecha es de ayer en la noche y el destinatario pues es una cuenta particular no no se cual es",
-                "openai-gpt4o-mini-transcribe":
-                    "este el monto es de tres mil doscientos pesos pues la fecha es de ayer en la noche y el destinatario pues es una cuenta particular no no se cual es",
-            },
-        },
+            "id": "conv-14-turn-15",
+            "locale": "es-MX",
+            "transcript": "Es, el monto es de 3200 pesos. Pues la fecha es de ayer en la noche y el destinatario pues es una cuenta particular, no, no sé cuál es.",
+            "hasAudio": false,
+            "submissions": {
+                "azure": "este el monto es de tres mil doscientos pesos pues la fecha es de ayer en la noche y el destinatario pues es una cuenta particular no se cual es",
+                "deepgram-nova3": "este el monto es de tres mil doscientos pesos pues la fecha es de ayer en la noche y el destinatario pues es una cuenta particular no no se cual es",
+                "elevenlabs-scribe-v2": "este el monto es de tres mil doscientos pesos pues la fecha es de ayer en la noche y el destinatario pues es una cuenta particular no no se cual es",
+                "google-chirp3": "este el monto es de tres mil doscientos pesos pues la fecha es de ayer en la noche y el destinatario pues es una cuenta particular no no se cual es",
+                "openai-gpt4o-mini-transcribe": "este el monto es de tres mil doscientos pesos pues la fecha es de ayer en la noche y el destinatario pues es una cuenta particular no no se cual es"
+            }
+        }
     ],
     "tr-TR": [
         {
-            id: "conv-41-turn-11",
-            locale: "tr-TR",
-            transcript: "Tamam, dinlersen söyleyeceğim Anna. Artı 90 123 0 90 45 67.",
-            hasAudio: true,
-            submissions: {
-                azure: "tamam dinlersin paylasimlar arti doksan bir yuz yirmi uc sifir doksan kirk bes altmis yedi",
-                "deepgram-nova3":
-                    "tamam dinlersin kolay yasayamamlar arti doksan yuz yirmi uc sifir doksan kirk bes altmis yedi",
-                "elevenlabs-scribe-v2":
-                    "tamam dinlersen paylasacagim anla arti doksan bir yuz yirmi uc sifir doksan kirk bes altmis yedi",
+            "id": "conv-41-turn-11",
+            "locale": "tr-TR",
+            "transcript": "Tamam, dinlersen söyleyeceğim Anna. Artı 90 123 0 90 45 67.",
+            "hasAudio": true,
+            "submissions": {
+                "azure": "tamam dinlersin paylasimlar arti doksan bir yuz yirmi uc sifir doksan kirk bes altmis yedi",
+                "deepgram-nova3": "tamam dinlersin kolay yasayamamlar arti doksan yuz yirmi uc sifir doksan kirk bes altmis yedi",
+                "elevenlabs-scribe-v2": "tamam dinlersen paylasacagim anla arti doksan bir yuz yirmi uc sifir doksan kirk bes altmis yedi",
                 "google-chirp3": "tamam dinler misin arti doksan yuz yirmi uc sifir doksan kirk bes altmis yedi",
-                "openai-gpt4o-mini-transcribe":
-                    "tamam dinleyecegim arti doksan yuz yirmi uc sifir doksan kirk bes altmis yedi",
-            },
+                "openai-gpt4o-mini-transcribe": "tamam dinleyecegim arti doksan yuz yirmi uc sifir doksan kirk bes altmis yedi"
+            }
         },
         {
-            id: "conv-22-turn-2",
-            locale: "tr-TR",
-            transcript: "Hayır C N 593 dediniz ama, ben yanlış mı anladım?",
-            hasAudio: false,
-            submissions: {
-                azure: "hayır eski döve beş yüz doksan üç dediniz ama ben yanlış mı anladım",
+            "id": "conv-22-turn-2",
+            "locale": "tr-TR",
+            "transcript": "Hayır C N 593 dediniz ama, ben yanlış mı anladım?",
+            "hasAudio": false,
+            "submissions": {
+                "azure": "hayır eski döve beş yüz doksan üç dediniz ama ben yanlış mı anladım",
                 "deepgram-nova3": "hayır eski c h m five hundred ninety three dediniz ama ben yanlış mı anladım",
                 "elevenlabs-scribe-v2": "hayır f değil d n beş yüz doksan üç dediniz ama ben yanlış mı anladım",
                 "google-chirp3": "hayır d n five hundred ninety three dediniz ama ben yanlış mı anladım",
-                "openai-gpt4o-mini-transcribe": "hayır beş yüz doksan üç dediniz ama ben yanlış mı anladım",
-            },
+                "openai-gpt4o-mini-transcribe": "hayır beş yüz doksan üç dediniz ama ben yanlış mı anladım"
+            }
         },
         {
-            id: "conv-40-turn-11",
-            locale: "tr-TR",
-            transcript:
-                "Email daha vermedin, email vereyim ben sana. Ahmet nokta Arslan A R S L A N at email nokta com.",
-            hasAudio: false,
-            submissions: {
-                azure: "email davranmadigini tekrar email verinden sonra ahmet arslan a r s l a n at email nokta com",
-                "deepgram-nova3":
-                    "email daha vermedim tekrar email vereyim ben sana ahmet nokta arslan arslan at email nokta com",
-                "elevenlabs-scribe-v2":
-                    "email daha vermedim tekrar email vereyim ben sana ahmet nokta arslan a r s l a n at email nokta com",
-                "google-chirp3":
-                    "email daha vermedim tekrar email vereyim ben sana ahmet nokta arslan a r s l a n at email nokta com",
-                "openai-gpt4o-mini-transcribe":
-                    "email adresine tekrar email vereyim ben sana ahmet nokta arslan a r s l a n at email nokta com",
-            },
+            "id": "conv-40-turn-11",
+            "locale": "tr-TR",
+            "transcript": "Email daha vermedin, email vereyim ben sana. Ahmet nokta Arslan A R S L A N at email nokta com.",
+            "hasAudio": false,
+            "submissions": {
+                "azure": "email davranmadigini tekrar email verinden sonra ahmet arslan a r s l a n at email nokta com",
+                "deepgram-nova3": "email daha vermedim tekrar email vereyim ben sana ahmet nokta arslan arslan at email nokta com",
+                "elevenlabs-scribe-v2": "email daha vermedim tekrar email vereyim ben sana ahmet nokta arslan a r s l a n at email nokta com",
+                "google-chirp3": "email daha vermedim tekrar email vereyim ben sana ahmet nokta arslan a r s l a n at email nokta com",
+                "openai-gpt4o-mini-transcribe": "email adresine tekrar email vereyim ben sana ahmet nokta arslan a r s l a n at email nokta com"
+            }
         },
         {
-            id: "conv-14-turn-10",
-            locale: "tr-TR",
-            transcript:
-                "E-posta adresi doğru ama adımda ve telefon numarasında hata var. Adımda son harf Zaynep, P olacak. Pırasanın P'si, siz T ile söylediniz. Zaynep Arslan olacak.",
-            hasAudio: false,
-            submissions: {
-                azure: "e posta adresi doğru ama adımda ve telefon numarasında hata var adımda son harf zaynep p olacak pırasanın ps'i siz t ile söylediniz zaynep arslan olacak",
-                "deepgram-nova3":
-                    "e posta adresi doğru ama adımda ve telefon numarasında hata var adımda son harf zaynap p olacak burasının psi siz tyle söylediniz zaynap arslan olacak",
-                "elevenlabs-scribe-v2":
-                    "yani e posta adresi doğru ama adımda ve telefon numarasında hata var adımda son harf zayneb p olacak pırasanın psi siz t ile söylediniz zayneb arslan olacak",
-                "google-chirp3":
-                    "e posta adresi doğru ama adımda ve telefon numarasında hata var adımda son harf zeynep p olacak pırasanın psi siz t ile söylediniz zeynep arslan olacak",
-                "openai-gpt4o-mini-transcribe":
-                    "yani e posta adresi doğru ama adımda ve telefon numarasında hata var adımda son harf zeynep t olacak pırasının p si siz t ile söylediniz zeynep arslan olacak",
-            },
+            "id": "conv-14-turn-10",
+            "locale": "tr-TR",
+            "transcript": "E-posta adresi doğru ama adımda ve telefon numarasında hata var. Adımda son harf Zaynep, P olacak. Pırasanın P'si, siz T ile söylediniz. Zaynep Arslan olacak.",
+            "hasAudio": false,
+            "submissions": {
+                "azure": "e posta adresi doğru ama adımda ve telefon numarasında hata var adımda son harf zaynep p olacak pırasanın ps'i siz t ile söylediniz zaynep arslan olacak",
+                "deepgram-nova3": "e posta adresi doğru ama adımda ve telefon numarasında hata var adımda son harf zaynap p olacak burasının psi siz tyle söylediniz zaynap arslan olacak",
+                "elevenlabs-scribe-v2": "yani e posta adresi doğru ama adımda ve telefon numarasında hata var adımda son harf zayneb p olacak pırasanın psi siz t ile söylediniz zayneb arslan olacak",
+                "google-chirp3": "e posta adresi doğru ama adımda ve telefon numarasında hata var adımda son harf zeynep p olacak pırasanın psi siz t ile söylediniz zeynep arslan olacak",
+                "openai-gpt4o-mini-transcribe": "yani e posta adresi doğru ama adımda ve telefon numarasında hata var adımda son harf zeynep t olacak pırasının p si siz t ile söylediniz zeynep arslan olacak"
+            }
         },
         {
-            id: "conv-2-turn-0",
-            locale: "tr-TR",
-            transcript: "Merhaba, son hesap ekstresinin kopyasına ihtiyacım var da.",
-            hasAudio: false,
-            submissions: {
-                azure: "merhaba son hesap ekstrimin bir kopyasina ihtiyacim var da",
+            "id": "conv-2-turn-0",
+            "locale": "tr-TR",
+            "transcript": "Merhaba, son hesap ekstresinin kopyasına ihtiyacım var da.",
+            "hasAudio": false,
+            "submissions": {
+                "azure": "merhaba son hesap ekstrimin bir kopyasina ihtiyacim var da",
                 "deepgram-nova3": "merhaba son hesap ekstresinin bir kopyasina ihtiyacim vardi",
                 "elevenlabs-scribe-v2": "merhaba son hesap ekstresinin bir kopyasina ihtiyacim var da",
                 "google-chirp3": "merhaba son hesap ekstresimin bir kopyasina ihtiyacim vardi",
-                "openai-gpt4o-mini-transcribe": "merhaba son hesap ekstresinin bir kopyasina ihtiyacim vardi da",
-            },
-        },
+                "openai-gpt4o-mini-transcribe": "merhaba son hesap ekstresinin bir kopyasina ihtiyacim vardi da"
+            }
+        }
     ],
     "vi-VN": [
         {
-            id: "conv-20-turn-14",
-            locale: "vi-VN",
-            transcript: "Không phải. Minh, minh là tên đó. Trần là họ đó. Minh chấm trần a còng email chấm com.",
-            hasAudio: true,
-            submissions: {
-                azure: "không phải minh minh là tên đó trần là họ đó minh trần a còng email com",
+            "id": "conv-20-turn-14",
+            "locale": "vi-VN",
+            "transcript": "Không phải. Minh, minh là tên đó. Trần là họ đó. Minh chấm trần a còng email chấm com.",
+            "hasAudio": true,
+            "submissions": {
+                "azure": "không phải minh minh là tên đó trần là họ đó minh trần a còng email com",
                 "deepgram-nova3": "phai minh minh la ten do tran la ho do minh cham tran a cong email cham com",
-                "elevenlabs-scribe-v2":
-                    "không phải minh minh là tên đó trần là họ đó minh chấm trần a còng email chấm com",
+                "elevenlabs-scribe-v2": "không phải minh minh là tên đó trần là họ đó minh chấm trần a còng email chấm com",
                 "google-chirp3": "không phải minh minh là tên đó trần là họ đó minh chấm trần a còng email chấm com",
-                "openai-gpt4o-mini-transcribe":
-                    "không phải minh minh là tên đó trần là họ đó minh chấm trần a còng email chấm com",
-            },
+                "openai-gpt4o-mini-transcribe": "không phải minh minh là tên đó trần là họ đó minh chấm trần a còng email chấm com"
+            }
         },
         {
-            id: "conv-26-turn-3",
-            locale: "vi-VN",
-            transcript:
-                "Tên của mình là Trần Minh. Email là minh chấm trần a còng Gmail chấm com. Số điện thoại là cộng 8 4 9 1 1 2 3 4 5 6 7 8. Địa chỉ là 1 2 3 đường Lê Lợi, Thành phố Hồ Chí Minh, 700000, Việt Nam.",
-            hasAudio: false,
-            submissions: {
-                azure: "ten cua minh la tran minh email la minh cham tran a cong gmail cham com so dien thoai la cong tam bon chin mot mot hai ba bon nam sau bay tam dia chi la mot hai ba duong le loi thanh pho ho chi minh bay tram nghin viet nam",
-                "deepgram-nova3":
-                    "tên của mình là trần minh email là minh chấm orggmail chấm com số điện thoại là cộng tám mươi bốn chín mươi mốt một hai ba bốn năm sáu bảy tám địa chỉ là một hai ba đường lê lợi thành phố hồ chí minh bảy trăm nghìn việt nam",
-                "elevenlabs-scribe-v2":
-                    "ten cua minh la tran minh email la minh cham tran a cong gmail cham com so dien thoai la cong tam tu chin mot mot hai ba bon nam sau bay tam dia chi la mot hai ba duong le loi thanh pho ho chi minh bay tram nghin viet nam",
-                "google-chirp3":
-                    "tên của mình là trần minh email là minh trần a còng gmail chấm com số điện thoại là cộng tám bốn chín một một hai ba bốn năm sáu bảy tám địa chỉ là một hai ba đường lê lợi thành phố hồ chí minh bảy trăm nghìn việt nam",
-                "openai-gpt4o-mini-transcribe":
-                    "tên của mình là trần minh email là minh trần a còng gmail chấm com số điện thoại là cộng tám bốn chín một một hai ba bốn năm sáu bảy tám địa chỉ là một hai ba đường lê lợi thành phố hồ chí minh bảy trăm nghìn việt nam",
-            },
+            "id": "conv-26-turn-3",
+            "locale": "vi-VN",
+            "transcript": "Tên của mình là Trần Minh. Email là minh chấm trần a còng Gmail chấm com. Số điện thoại là cộng 8 4 9 1 1 2 3 4 5 6 7 8. Địa chỉ là 1 2 3 đường Lê Lợi, Thành phố Hồ Chí Minh, 700000, Việt Nam.",
+            "hasAudio": false,
+            "submissions": {
+                "azure": "ten cua minh la tran minh email la minh cham tran a cong gmail cham com so dien thoai la cong tam bon chin mot mot hai ba bon nam sau bay tam dia chi la mot hai ba duong le loi thanh pho ho chi minh bay tram nghin viet nam",
+                "deepgram-nova3": "tên của mình là trần minh email là minh chấm orggmail chấm com số điện thoại là cộng tám mươi bốn chín mươi mốt một hai ba bốn năm sáu bảy tám địa chỉ là một hai ba đường lê lợi thành phố hồ chí minh bảy trăm nghìn việt nam",
+                "elevenlabs-scribe-v2": "ten cua minh la tran minh email la minh cham tran a cong gmail cham com so dien thoai la cong tam tu chin mot mot hai ba bon nam sau bay tam dia chi la mot hai ba duong le loi thanh pho ho chi minh bay tram nghin viet nam",
+                "google-chirp3": "tên của mình là trần minh email là minh trần a còng gmail chấm com số điện thoại là cộng tám bốn chín một một hai ba bốn năm sáu bảy tám địa chỉ là một hai ba đường lê lợi thành phố hồ chí minh bảy trăm nghìn việt nam",
+                "openai-gpt4o-mini-transcribe": "tên của mình là trần minh email là minh trần a còng gmail chấm com số điện thoại là cộng tám bốn chín một một hai ba bốn năm sáu bảy tám địa chỉ là một hai ba đường lê lợi thành phố hồ chí minh bảy trăm nghìn việt nam"
+            }
         },
         {
-            id: "conv-42-turn-2",
-            locale: "vi-VN",
-            transcript: "C N 5 8 8 hay là C N 5 8 7?",
-            hasAudio: false,
-            submissions: {
-                azure: "c n five eight eight hay là c n five eight seven",
+            "id": "conv-42-turn-2",
+            "locale": "vi-VN",
+            "transcript": "C N 5 8 8 hay là C N 5 8 7?",
+            "hasAudio": false,
+            "submissions": {
+                "azure": "c n five eight eight hay là c n five eight seven",
                 "deepgram-nova3": "c n năm trăm tám mươi tám hay là c n năm trăm tám mươi bảy",
                 "elevenlabs-scribe-v2": "c n five eight eight hay là c n five eight seven",
                 "google-chirp3": "c n five eight eight hay là c n five eight seven",
-                "openai-gpt4o-mini-transcribe": "c n five eight five hay là c n five eight seven",
-            },
+                "openai-gpt4o-mini-transcribe": "c n five eight five hay là c n five eight seven"
+            }
         },
         {
-            id: "conv-7-turn-13",
-            locale: "vi-VN",
-            transcript: "Có thể đẩy nhanh tiến độ được không?",
-            hasAudio: false,
-            submissions: {
-                azure: "có thể nào đẩy nhanh tiến độ được không",
+            "id": "conv-7-turn-13",
+            "locale": "vi-VN",
+            "transcript": "Có thể đẩy nhanh tiến độ được không?",
+            "hasAudio": false,
+            "submissions": {
+                "azure": "có thể nào đẩy nhanh tiến độ được không",
                 "deepgram-nova3": "có thể nào đẩy nhanh tiến độ được không",
                 "elevenlabs-scribe-v2": "có thể nào đẩy nhanh tiến độ được không",
                 "google-chirp3": "có thể nào đẩy nhanh tiến độ được không",
-                "openai-gpt4o-mini-transcribe": "có thể nào đẩy nhanh tiến độ được không",
-            },
+                "openai-gpt4o-mini-transcribe": "có thể nào đẩy nhanh tiến độ được không"
+            }
         },
         {
-            id: "conv-3-turn-7",
-            locale: "vi-VN",
-            transcript: "Không. Không phải. Đúng là minh chấm trần a còng email chấm com.",
-            hasAudio: false,
-            submissions: {
-                azure: "khong khong khong phai dung la minh cham tran a cong email cham com",
+            "id": "conv-3-turn-7",
+            "locale": "vi-VN",
+            "transcript": "Không. Không phải. Đúng là minh chấm trần a còng email chấm com.",
+            "hasAudio": false,
+            "submissions": {
+                "azure": "khong khong khong phai dung la minh cham tran a cong email cham com",
                 "deepgram-nova3": "không không không phải đúng là nguyên chấm chờ á cầu bị nghèo chống cược",
                 "elevenlabs-scribe-v2": "không không phải đúng là minh chấm trần a còng email chấm com",
                 "google-chirp3": "khong khong bay dung la linh cham tran a cong email cham com",
-                "openai-gpt4o-mini-transcribe":
-                    "không không không phải đúng là nguyễn chấm trần đã cộng điện theo trấn cơ",
-            },
-        },
+                "openai-gpt4o-mini-transcribe": "không không không phải đúng là nguyễn chấm trần đã cộng điện theo trấn cơ"
+            }
+        }
     ],
     "zh-CN": [
         {
-            id: "conv-4-turn-12",
-            locale: "zh-CN",
-            transcript: "你还没听到我的正确的姓名，我的姓名是君灵。",
-            hasAudio: true,
-            submissions: {
-                azure: "你还没听到我的正确的姓名 我的姓名是君灵",
+            "id": "conv-4-turn-12",
+            "locale": "zh-CN",
+            "transcript": "你还没听到我的正确的姓名，我的姓名是君灵。",
+            "hasAudio": true,
+            "submissions": {
+                "azure": "你还没听到我的正确的姓名 我的姓名是君灵",
                 "deepgram-nova3": "你 还 没 听 到 我 的 正确 的 姓名 我 的 姓名 是 君灵",
                 "elevenlabs-scribe-v2": "你 还 没 听 到 我 的 正确 的 姓名 我 的 姓名 是 君灵",
                 "google-chirp3": "你 还 没 听 到 我 的 正确 的 姓名 我 的 姓名 是 君灵",
-                "openai-gpt4o-mini-transcribe": "你 还 没 听 到 我 的 正确 的 姓名 我 的 姓名 是 君灵",
-            },
+                "openai-gpt4o-mini-transcribe": "你 还 没 听 到 我 的 正确 的 姓名 我 的 姓名 是 君灵"
+            }
         },
         {
-            id: "conv-0-turn-6",
-            locale: "zh-CN",
-            transcript: "我的邮箱地址是美林 at email dot com。",
-            hasAudio: false,
-            submissions: {
-                azure: "我的邮箱地址是美玲 at email dot com",
+            "id": "conv-0-turn-6",
+            "locale": "zh-CN",
+            "transcript": "我的邮箱地址是美林 at email dot com。",
+            "hasAudio": false,
+            "submissions": {
+                "azure": "我的邮箱地址是美玲 at email dot com",
                 "deepgram-nova3": "有相地址是maylin at email dot com",
                 "elevenlabs-scribe-v2": "我的邮箱地址是美林 at email dot com",
                 "google-chirp3": "我的邮箱地址是美林 at email dot com",
-                "openai-gpt4o-mini-transcribe": "我的邮箱地址是美林 at email dot com",
-            },
+                "openai-gpt4o-mini-transcribe": "我的邮箱地址是美林 at email dot com"
+            }
         },
         {
-            id: "conv-7-turn-6",
-            locale: "zh-CN",
-            transcript: "请问，请问，再等一下，是 C N 3 8 9。",
-            hasAudio: false,
-            submissions: {
-                azure: "请问 请问 再等一下 是 c n three eight nine",
+            "id": "conv-7-turn-6",
+            "locale": "zh-CN",
+            "transcript": "请问，请问，再等一下，是 C N 3 8 9。",
+            "hasAudio": false,
+            "submissions": {
+                "azure": "请问 请问 再等一下 是 c n three eight nine",
                 "deepgram-nova3": "再等一下 是 c n three eight nine",
                 "elevenlabs-scribe-v2": "请问 请问 再等一下 是 c n three eight nine",
                 "google-chirp3": "请问 请问 再 等 一 下 是 c n three eight nine",
-                "openai-gpt4o-mini-transcribe": "请问 请问 这道你叫是 c n three eight nine",
-            },
+                "openai-gpt4o-mini-transcribe": "请问 请问 这道你叫是 c n three eight nine"
+            }
         },
         {
-            id: "conv-1-turn-10",
-            locale: "zh-CN",
-            transcript: "是美点玲 at email dot com。",
-            hasAudio: false,
-            submissions: {
-                azure: "she made diane ling at email dot com",
+            "id": "conv-1-turn-10",
+            "locale": "zh-CN",
+            "transcript": "是美点玲 at email dot com。",
+            "hasAudio": false,
+            "submissions": {
+                "azure": "she made diane ling at email dot com",
                 "deepgram-nova3": "是美点玲 email dot com",
                 "elevenlabs-scribe-v2": "是美点玲 at email dot com",
                 "google-chirp3": "是美点玲 at email dot com",
-                "openai-gpt4o-mini-transcribe": "是美点玲 at email dot com",
-            },
+                "openai-gpt4o-mini-transcribe": "是美点玲 at email dot com"
+            }
         },
         {
-            id: "conv-39-turn-17",
-            locale: "zh-CN",
-            transcript: "对，但是我的邮箱是君临 at email dot com。",
-            hasAudio: false,
-            submissions: {
-                azure: "对 但是我的邮箱是君临 at email dot com",
+            "id": "conv-39-turn-17",
+            "locale": "zh-CN",
+            "transcript": "对，但是我的邮箱是君临 at email dot com。",
+            "hasAudio": false,
+            "submissions": {
+                "azure": "对 但是我的邮箱是君临 at email dot com",
                 "deepgram-nova3": "对但是我的邮箱是君临 at email dot com",
                 "elevenlabs-scribe-v2": "对 但是我的邮箱是君临 at email dot com",
                 "google-chirp3": "对 但是我的邮箱是君临 at email dot com",
-                "openai-gpt4o-mini-transcribe": "对 但是我的邮箱是君临 at email dot com",
-            },
-        },
-    ],
+                "openai-gpt4o-mini-transcribe": "对 但是我的邮箱是君临 at email dot com"
+            }
+        }
+    ]
 };
 
 /**
@@ -637,11 +590,13 @@ export const SAMPLE_UTTERANCES = {
  */
 export function getProviderScore(provider, metricKey, locale) {
     if (locale === "overall") {
-        const scores = LOCALES.map((l) => {
+        const scores = LOCALES.map(l => {
             const result = provider.localeResults[l.code];
-            return result && result[metricKey] !== undefined && result[metricKey] !== null ? result[metricKey] : null;
+            return result && result[metricKey] !== undefined && result[metricKey] !== null
+                ? result[metricKey]
+                : null;
         });
-        if (scores.some((s) => s === null)) return null;
+        if (scores.some(s => s === null)) return null;
         const avg = scores.reduce((a, b) => a + b, 0) / scores.length;
         return Math.round(avg * 100) / 100;
     }
@@ -657,7 +612,7 @@ export function getProviderScore(provider, metricKey, locale) {
  * Get per-locale scores for a provider (used in expanded rows).
  */
 export function getProviderLocaleScores(provider, metricKey) {
-    return LOCALES.map((locale) => {
+    return LOCALES.map(locale => {
         const score = getProviderScore(provider, metricKey, locale.code);
         return {
             ...locale,

--- a/results/leaderboard.json
+++ b/results/leaderboard.json
@@ -209,36 +209,36 @@
           "wer": 0.0391,
           "significantWer": 0.0484,
           "qualityScore": null,
-          "latencyP50Ms": 663.7,
-          "latencyP95Ms": 1327.7
+          "latencyP50Ms": 616.9,
+          "latencyP95Ms": 1091.9
         },
         "es-MX": {
           "wer": 0.1113,
           "significantWer": 0.1465,
           "qualityScore": null,
-          "latencyP50Ms": 659.0,
-          "latencyP95Ms": 1375.4
+          "latencyP50Ms": 676.7,
+          "latencyP95Ms": 1215.8
         },
         "tr-TR": {
           "wer": 0.1133,
           "significantWer": 0.1856,
           "qualityScore": null,
-          "latencyP50Ms": 696.2,
-          "latencyP95Ms": 1652.0
+          "latencyP50Ms": 731.4,
+          "latencyP95Ms": 1337.1
         },
         "vi-VN": {
           "wer": 0.209,
           "significantWer": 0.3203,
           "qualityScore": null,
-          "latencyP50Ms": 661.8,
-          "latencyP95Ms": 1281.2
+          "latencyP50Ms": 691.3,
+          "latencyP95Ms": 1340.3
         },
         "zh-CN": {
           "wer": 0.1596,
           "significantWer": 0.2137,
           "qualityScore": null,
-          "latencyP50Ms": 566.0,
-          "latencyP95Ms": 1116.1
+          "latencyP50Ms": 620.5,
+          "latencyP95Ms": 1248.8
         }
       }
     }

--- a/results/openai-gpt4o-mini-transcribe/scores.json
+++ b/results/openai-gpt4o-mini-transcribe/scores.json
@@ -9,8 +9,8 @@
       "significantWer": 0.0484,
       "utteranceCount": 817,
       "unintelligibleCount": 0,
-      "latencyP50Ms": 663.7,
-      "latencyP95Ms": 1327.7
+      "latencyP50Ms": 616.9,
+      "latencyP95Ms": 1091.9
     },
     "es-MX": {
       "wer": 0.1113,
@@ -18,8 +18,8 @@
       "significantWer": 0.1465,
       "utteranceCount": 792,
       "unintelligibleCount": 0,
-      "latencyP50Ms": 659.0,
-      "latencyP95Ms": 1375.4
+      "latencyP50Ms": 676.7,
+      "latencyP95Ms": 1215.8
     },
     "tr-TR": {
       "wer": 0.1133,
@@ -27,8 +27,8 @@
       "significantWer": 0.1856,
       "utteranceCount": 846,
       "unintelligibleCount": 0,
-      "latencyP50Ms": 696.2,
-      "latencyP95Ms": 1652.0
+      "latencyP50Ms": 731.4,
+      "latencyP95Ms": 1337.1
     },
     "vi-VN": {
       "wer": 0.209,
@@ -36,8 +36,8 @@
       "significantWer": 0.3203,
       "utteranceCount": 975,
       "unintelligibleCount": 0,
-      "latencyP50Ms": 661.8,
-      "latencyP95Ms": 1281.2
+      "latencyP50Ms": 691.3,
+      "latencyP95Ms": 1340.3
     },
     "zh-CN": {
       "wer": 0.1596,
@@ -45,8 +45,8 @@
       "significantWer": 0.2137,
       "utteranceCount": 840,
       "unintelligibleCount": 0,
-      "latencyP50Ms": 566.0,
-      "latencyP95Ms": 1116.1
+      "latencyP50Ms": 620.5,
+      "latencyP95Ms": 1248.8
     }
   },
   "overall": {
@@ -55,7 +55,7 @@
     "significantWer": 0.1887,
     "utteranceCount": 4270,
     "unintelligibleCount": 0,
-    "latencyP50Ms": 664.8,
-    "latencyP95Ms": 1358.8
+    "latencyP50Ms": 667.9,
+    "latencyP95Ms": 1249.7
   }
 }


### PR DESCRIPTION
## Summary

Synced from voice-transcription-benchmark PR #56. Replaces bulk-run (concurrency 10) latency with dedicated concurrency-1 measurements across all 4,270 utterances.

| Locale | p50 | p95 |
|--------|-----|-----|
| en-US | 617ms | 1,092ms |
| es-MX | 677ms | 1,216ms |
| tr-TR | 731ms | 1,337ms |
| vi-VN | 691ms | 1,340ms |
| zh-CN | 620ms | 1,249ms |
| **Overall** | **668ms** | **1,250ms** |

### Files changed
- `results/openai-gpt4o-mini-transcribe/scores.json`
- `results/leaderboard.json`
- `leaderboard/src/data/data.js`

Made with [Cursor](https://cursor.com)