### PR TITLE
Drop back-compat fallbacks for NORMALIZE_AGAINST_GOLD_PROMPT

### DIFF
--- a/scoring/metrics.py
+++ b/scoring/metrics.py
@@ -30,50 +30,25 @@ from scoring.llm import (
 
 
 def _load_prompts():
-    """Lazy-load scoring prompts so modules that don't need LLM calls can import metrics freely.
+    """Lazy-load scoring prompts.
 
-    Returns (normalize_prompt, sig_errors_prompt). Prefers the new split
-    prompts introduced for canonical gold normalization (item 1):
-      - ``NORMALIZE_PRED_AGAINST_GOLD_PROMPT`` (blind-gold + prediction)
-    and falls back to the legacy ``NORMALIZE_AGAINST_GOLD_PROMPT`` when the
-    secret ``scoring/prompts.py`` hasn't been updated yet.
+    Returns ``(NORMALIZE_PRED_AGAINST_GOLD_PROMPT, SIGNIFICANT_WORD_ERRORS_PROMPT)``.
+    Kept lazy so modules that don't touch the LLM (validator, leaderboard
+    update) can import ``scoring.metrics`` without the secret prompts file.
     """
-    from scoring import prompts as _prompts  # type: ignore[attr-defined]
+    from scoring.prompts import (  # type: ignore[attr-defined]
+        NORMALIZE_PRED_AGAINST_GOLD_PROMPT,
+        SIGNIFICANT_WORD_ERRORS_PROMPT,
+    )
 
-    normalize_prompt = getattr(_prompts, "NORMALIZE_PRED_AGAINST_GOLD_PROMPT", None)
-    if normalize_prompt is None:
-        normalize_prompt = getattr(_prompts, "NORMALIZE_AGAINST_GOLD_PROMPT", None)
-    if normalize_prompt is None:
-        raise ImportError(
-            "scoring.prompts is missing NORMALIZE_PRED_AGAINST_GOLD_PROMPT "
-            "(and legacy NORMALIZE_AGAINST_GOLD_PROMPT). Make sure the "
-            "SCORING_PROMPTS_PY secret has been injected."
-        )
-    sig_prompt = _prompts.SIGNIFICANT_WORD_ERRORS_PROMPT
-    return normalize_prompt, sig_prompt
+    return NORMALIZE_PRED_AGAINST_GOLD_PROMPT, SIGNIFICANT_WORD_ERRORS_PROMPT
 
 
 def _load_gold_prompt() -> str:
-    """Return the canonical gold-only normalization prompt.
+    """Return the canonical gold-only normalization prompt."""
+    from scoring.prompts import NORMALIZE_GOLD_PROMPT  # type: ignore[attr-defined]
 
-    Prefers ``NORMALIZE_GOLD_PROMPT``. Falls back to the legacy
-    ``NORMALIZE_AGAINST_GOLD_PROMPT`` (which also receives the prediction,
-    but callers pass an empty ``actual_transcript``) when the split prompts
-    haven't been deployed yet.
-    """
-    from scoring import prompts as _prompts  # type: ignore[attr-defined]
-
-    gold_prompt = getattr(_prompts, "NORMALIZE_GOLD_PROMPT", None)
-    if gold_prompt is not None:
-        return gold_prompt
-    legacy = getattr(_prompts, "NORMALIZE_AGAINST_GOLD_PROMPT", None)
-    if legacy is not None:
-        return legacy
-    raise ImportError(
-        "scoring.prompts is missing NORMALIZE_GOLD_PROMPT (and legacy "
-        "NORMALIZE_AGAINST_GOLD_PROMPT). Make sure the SCORING_PROMPTS_PY "
-        "secret has been injected."
-    )
+    return NORMALIZE_GOLD_PROMPT
 
 
 @dataclass

--- a/scoring/normalize.py
+++ b/scoring/normalize.py
@@ -13,10 +13,6 @@ writes ``<id>.txt`` per utterance. The submitter-specific
 ``<id>.gold.txt`` files are no longer written here; consumers should read
 the canonical cache instead.
 
-For back-compat (and so the legacy ``NORMALIZE_AGAINST_GOLD_PROMPT`` still
-works), this script falls back to the old symmetric-normalization flow
-when the new ``NORMALIZE_PRED_AGAINST_GOLD_PROMPT`` isn't available yet.
-
 Usage:
     python -m scoring.normalize --submission-dir submissions/raw/deepgram-nova3
 """
@@ -32,7 +28,6 @@ load_dotenv()
 
 from scoring.llm import (
     NORMALIZE_PRED_SCHEMA,
-    NORMALIZE_SCHEMA,
     get_responses,
     load_responses,
 )
@@ -105,28 +100,11 @@ def load_transcript_pairs(
     return rows
 
 
-def _select_pred_prompt() -> tuple[str, dict, str]:
-    """Return (prompt_template, response_schema, mode).
+def _load_pred_prompt() -> tuple[str, dict]:
+    """Return ``(prompt_template, response_schema)`` for prediction normalization."""
+    from scoring.prompts import NORMALIZE_PRED_AGAINST_GOLD_PROMPT  # type: ignore[attr-defined]
 
-    Prefers the new prediction-only prompt (gold is already normalized and
-    passed in only for style reference). Falls back to the legacy symmetric
-    prompt. ``mode`` is one of ``"pred_only"`` or ``"legacy_symmetric"``
-    and controls how we pull fields out of the response.
-    """
-    from scoring import prompts as _prompts  # type: ignore[attr-defined]
-
-    pred_prompt = getattr(_prompts, "NORMALIZE_PRED_AGAINST_GOLD_PROMPT", None)
-    if pred_prompt is not None:
-        return pred_prompt, NORMALIZE_PRED_SCHEMA, "pred_only"
-    legacy = getattr(_prompts, "NORMALIZE_AGAINST_GOLD_PROMPT", None)
-    if legacy is not None:
-        print("WARNING: using legacy NORMALIZE_AGAINST_GOLD_PROMPT; gold will be re-derived per prediction.")
-        return legacy, NORMALIZE_SCHEMA, "legacy_symmetric"
-    raise ImportError(
-        "scoring.prompts is missing NORMALIZE_PRED_AGAINST_GOLD_PROMPT "
-        "(and legacy NORMALIZE_AGAINST_GOLD_PROMPT). Make sure the "
-        "SCORING_PROMPTS_PY secret has been injected."
-    )
+    return NORMALIZE_PRED_AGAINST_GOLD_PROMPT, NORMALIZE_PRED_SCHEMA
 
 
 def main():
@@ -259,8 +237,7 @@ def main():
         print("All files already normalized")
         return
 
-    prompt_template, response_schema, prompt_mode = _select_pred_prompt()
-    print(f"Using prompt mode: {prompt_mode}")
+    prompt_template, response_schema = _load_pred_prompt()
 
     total = len(to_normalize)
     batch_size = 100

--- a/scoring/normalize_gold.py
+++ b/scoring/normalize_gold.py
@@ -29,7 +29,6 @@ load_dotenv()
 
 from scoring.llm import (
     NORMALIZE_GOLD_SCHEMA,
-    NORMALIZE_SCHEMA,
     get_responses,
     load_responses,
 )
@@ -83,28 +82,8 @@ def write_cached_gold_hash(cache_dir: Path, digest: str) -> None:
 
 
 def _format_gold_prompt(prompt_template: str, gold: str) -> str:
-    """Format the gold-normalization prompt.
-
-    Works with both the new single-input prompt (``NORMALIZE_GOLD_PROMPT``
-    expects only ``{expected_transcript}``) and the legacy two-input prompt
-    (``NORMALIZE_AGAINST_GOLD_PROMPT`` expects both ``{expected_transcript}``
-    and ``{actual_transcript}`` — we pass an empty prediction). This lets
-    the code-only PR land before the secret prompts file is updated.
-    """
-    try:
-        return prompt_template.format(expected_transcript=gold)
-    except KeyError:
-        return prompt_template.format(expected_transcript=gold, actual_transcript="")
-
-
-def _response_schema_for(prompt_template: str) -> dict:
-    """Pick the JSON schema that matches the prompt template in use."""
-    # The new single-input prompt only produces normalized_expected. The
-    # legacy two-input prompt produces both expected and actual; we still
-    # honor its schema so calls don't fail validation.
-    if "{actual_transcript}" in prompt_template:
-        return NORMALIZE_SCHEMA
-    return NORMALIZE_GOLD_SCHEMA
+    """Format the gold-only normalization prompt with the single gold input."""
+    return prompt_template.format(expected_transcript=gold)
 
 
 def _extract_normalized_gold(resp: object) -> str | None:
@@ -192,7 +171,7 @@ def main():
         return
 
     prompt_template = _load_gold_prompt()
-    response_format = _response_schema_for(prompt_template)
+    response_format = NORMALIZE_GOLD_SCHEMA
 
     total = len(to_normalize)
     batch_size = 100

--- a/scoring/score.py
+++ b/scoring/score.py
@@ -68,9 +68,8 @@ def _collect_judge_block() -> dict:
 
     Records the pinned model / temperature / seed from scoring.llm plus the
     (truncated) SHA of each prompt constant in scoring.prompts. Missing
-    prompts (e.g. in the back-compat window before the secret is updated)
-    record an empty string so the drift-checker still catches partial
-    rollouts.
+    prompts record an empty SHA so the drift-checker still catches the
+    gap instead of silently omitting the field.
     """
     import datetime
 
@@ -87,17 +86,13 @@ def _collect_judge_block() -> dict:
             return ""
         return prompt_sha(val)
 
-    # Prefer the new canonical-gold split; fall back to the legacy prompt.
-    gold_prompt_sha = _sha("NORMALIZE_GOLD_PROMPT") or _sha("NORMALIZE_AGAINST_GOLD_PROMPT")
-    pred_prompt_sha = _sha("NORMALIZE_PRED_AGAINST_GOLD_PROMPT") or _sha("NORMALIZE_AGAINST_GOLD_PROMPT")
-
     return {
         "model": JUDGE_CONFIG["model"],
         "modelSnapshot": JUDGE_CONFIG["model"],
         "temperature": JUDGE_CONFIG["temperature"],
         "seed": JUDGE_CONFIG["seed"],
-        "normalizeGoldPromptSha": gold_prompt_sha,
-        "normalizePredPromptSha": pred_prompt_sha,
+        "normalizeGoldPromptSha": _sha("NORMALIZE_GOLD_PROMPT"),
+        "normalizePredPromptSha": _sha("NORMALIZE_PRED_AGAINST_GOLD_PROMPT"),
         "significantErrorsPromptSha": _sha("SIGNIFICANT_WORD_ERRORS_PROMPT"),
         "scoredAt": datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds"),
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,10 +18,6 @@ _STUB_NORMALIZE_PRED_AGAINST_GOLD_PROMPT = (
     "Stub prediction-against-normalized-gold prompt. "
     "expected_transcript={expected_transcript}\nactual_transcript={actual_transcript}"
 )
-_STUB_NORMALIZE_AGAINST_GOLD_PROMPT = (
-    "Stub legacy symmetric-normalization prompt. "
-    "expected_transcript={expected_transcript}\nactual_transcript={actual_transcript}"
-)
 _STUB_SIGNIFICANT_WORD_ERRORS_PROMPT = (
     "Stub significant-error scoring prompt. "
     "expected_transcript={expected_transcript}\nactual_transcript={actual_transcript}\nerrors={errors}"
@@ -34,7 +30,6 @@ def _install_prompt_stub() -> None:
     mod = types.ModuleType("scoring.prompts")
     mod.NORMALIZE_GOLD_PROMPT = _STUB_NORMALIZE_GOLD_PROMPT
     mod.NORMALIZE_PRED_AGAINST_GOLD_PROMPT = _STUB_NORMALIZE_PRED_AGAINST_GOLD_PROMPT
-    mod.NORMALIZE_AGAINST_GOLD_PROMPT = _STUB_NORMALIZE_AGAINST_GOLD_PROMPT
     mod.SIGNIFICANT_WORD_ERRORS_PROMPT = _STUB_SIGNIFICANT_WORD_ERRORS_PROMPT
     sys.modules["scoring.prompts"] = mod
 


### PR DESCRIPTION
## Summary

The legacy symmetric `NORMALIZE_AGAINST_GOLD_PROMPT` was removed from the `SCORING_PROMPTS_PY` secret when the canonical split (`NORMALIZE_GOLD_PROMPT` + `NORMALIZE_PRED_AGAINST_GOLD_PROMPT`) landed, so the `getattr`-based fallback paths introduced in #20 are now unreachable. This PR inlines them.

- **`scoring/metrics.py`**: `_load_prompts` / `_load_gold_prompt` become direct imports of the canonical names.
- **`scoring/normalize.py`**: `_select_pred_prompt` → `_load_pred_prompt`; no more `prompt_mode` tuple, no legacy `NORMALIZE_SCHEMA` path. Drops the "Falls back to legacy" paragraph from the module docstring.
- **`scoring/normalize_gold.py`**: `_format_gold_prompt` is a one-liner; `_response_schema_for` gone — we always use `NORMALIZE_GOLD_SCHEMA`.
- **`scoring/score.py`**: `_collect_judge_block` drops the `_sha("NORMALIZE_GOLD_PROMPT") or _sha("NORMALIZE_AGAINST_GOLD_PROMPT")` fallbacks.
- **`tests/conftest.py`**: removes the `_STUB_NORMALIZE_AGAINST_GOLD_PROMPT` stub.

Net: -79 lines, no behavior change.

## Scope

Pure dead-code cleanup. This does **not** touch the back-compat fences for:
- legacy flat `latency.json` (still accepted with a warning — scheduled for the rollout PR)
- legacy `latencyP50/95Ms` field aliases in leaderboard data (same reason)

Those drop when the rollout PR migrates every submission to the new latency schema.

## Test plan

- [x] `pytest tests/` — 29/29 green
- [x] `ruff check scoring/ scripts/ tests/` + `ruff format --check` clean
- [x] `pre-commit run --from-ref origin/main --to-ref HEAD` clean
- [x] `scoring/validate.py` against all 5 existing submissions — all pass
- [ ] CI lint + validate-submission jobs green on this PR

Made with [Cursor](https://cursor.com)