### PR TITLE
Bake new-schema latency.json into transcribe.py + promote tmp/ helpers to scripts/

### DIFF
--- a/scripts/aggregate_variance.py
+++ b/scripts/aggregate_variance.py
@@ -1,0 +1,230 @@
+"""Aggregate per-utterance scoring details across waves into the
+N=4 variance block of ``results/significance.json``.
+
+Inputs (per provider, per locale, one detail JSON per utterance):
+  * Wave A (published):    results/<provider>/details/<locale>/*.json
+  * Wave B (variance run): tmp/variance_runs/wave-b/_results/<provider>/details/<locale>/*.json
+  * Wave C (variance run): tmp/variance_runs/wave-c/_results/<provider>/details/<locale>/*.json
+  * Wave D (variance run): tmp/variance_runs/wave-d/_results/<provider>/details/<locale>/*.json
+
+Per detail file we read:
+  * ``werEdits`` + ``werRefWords`` -> corpus WER per locale
+    = sum(werEdits) / sum(werRefWords) across the locale
+  * ``majorErrorsCount`` + ``totalWordsCount`` -> corpus sigWER per locale
+    = sum(majorErrorsCount) / sum(totalWordsCount) across the locale
+  * ``unintelligible`` rows are skipped (they have null edits / null
+    sigWer in score.py).
+
+For each (provider, locale) we get one corpus WER and one corpus sigWER
+per wave -> four samples -> mean and std (ddof=1, sample std).
+
+Writes the new ``variance`` block back into
+``results/significance.json``, preserving the ``providers`` and
+``metrics`` blocks (refreshed by ``scripts/significance_test.py`` in a
+separate step). Adds an inline ``_note`` calling out that the new
+variance includes provider transcription noise.
+
+Usage:
+    .venv/bin/python scripts/aggregate_variance.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_SIG_PATH = REPO_ROOT / "results" / "significance.json"
+DEFAULT_VARIANCE_LOCALES = ["en-US", "zh-CN"]
+DEFAULT_PROVIDERS = [
+    "deepgram-nova3",
+    "google-chirp3",
+    "azure",
+    "elevenlabs-scribe-v2",
+    "openai-gpt4o-mini-transcribe",
+]
+
+WAVE_PATHS = {
+    "a": REPO_ROOT / "results",
+    "b": REPO_ROOT / "tmp" / "variance_runs" / "wave-b" / "_results",
+    "c": REPO_ROOT / "tmp" / "variance_runs" / "wave-c" / "_results",
+    "d": REPO_ROOT / "tmp" / "variance_runs" / "wave-d" / "_results",
+}
+
+
+def corpus_metrics_for_wave(
+    wave_results_root: Path, provider: str, locale: str
+) -> tuple[float | None, float | None, int]:
+    """Return (corpus_wer, utterance_error_rate, n_utterances) for one wave/provider/locale.
+
+    Must match the definitions used by ``scoring.score``'s flush so the
+    variance block is directly comparable to the published overall /
+    per-locale numbers:
+
+    - ``corpus WER = sum(werEdits) / sum(werRefWords)`` (edits per reference word)
+    - ``UER = n_utt_with_any_major_error / n_utt_scored`` (fraction of
+      utterances where ``majorErrorsCount > 0``). This is the LEADERBOARD
+      number under the field ``significantWer``.
+
+    Returns (None, None, 0) if the details directory is missing.
+    """
+    details_dir = wave_results_root / provider / "details" / locale
+    if not details_dir.is_dir():
+        return None, None, 0
+
+    edits_sum = 0
+    ref_sum = 0
+    sig_wer_scored = 0  # utterances with significantWer != None
+    sig_wer_errorful = 0  # utterances with majorErrorsCount > 0
+    n = 0
+    for detail_path in sorted(details_dir.glob("*.json")):
+        with detail_path.open("r", encoding="utf-8") as f:
+            d = json.load(f)
+        n += 1
+        if d.get("unintelligible"):
+            continue
+        edits = d.get("werEdits")
+        ref_words = d.get("werRefWords")
+        if edits is not None and ref_words is not None:
+            edits_sum += edits
+            ref_sum += ref_words
+        if d.get("significantWer") is not None:
+            sig_wer_scored += 1
+            major = d.get("majorErrorsCount") or 0
+            if major > 0:
+                sig_wer_errorful += 1
+
+    wer = (edits_sum / ref_sum) if ref_sum > 0 else None
+    uer = (sig_wer_errorful / sig_wer_scored) if sig_wer_scored > 0 else None
+    return wer, uer, n
+
+
+def sample_mean_std(values: list[float]) -> tuple[float, float]:
+    """Sample mean and std (ddof=1)."""
+    if not values:
+        return 0.0, 0.0
+    mean = sum(values) / len(values)
+    if len(values) < 2:
+        return mean, 0.0
+    var = sum((v - mean) ** 2 for v in values) / (len(values) - 1)
+    return mean, math.sqrt(var)
+
+
+def aggregate(
+    providers: list[str],
+    locales: list[str],
+    waves: list[str],
+    require_all_waves: bool,
+) -> tuple[dict, list[str]]:
+    """Build the variance dict. Returns (variance_block, warnings)."""
+    variance: dict = {}
+    warnings: list[str] = []
+    for provider in providers:
+        per_locale: dict = {}
+        for locale in locales:
+            wer_samples: list[float] = []
+            sig_samples: list[float] = []
+            wave_ns: dict[str, int] = {}
+            for wave in waves:
+                root = WAVE_PATHS[wave]
+                wer, sig, n = corpus_metrics_for_wave(root, provider, locale)
+                wave_ns[wave] = n
+                if wer is None or sig is None:
+                    msg = f"  WARN: missing wave {wave} details for {provider}/{locale} (root={root}, n_files={n})"
+                    warnings.append(msg)
+                    if require_all_waves:
+                        continue
+                else:
+                    wer_samples.append(wer)
+                    sig_samples.append(sig)
+
+            wer_mean, wer_std = sample_mean_std(wer_samples)
+            sig_mean, sig_std = sample_mean_std(sig_samples)
+            per_locale[locale] = {
+                "wer": {"mean": round(wer_mean, 4), "std": round(wer_std, 4)},
+                "significantWer": {"mean": round(sig_mean, 4), "std": round(sig_std, 4)},
+                "_n_waves": len(wer_samples),
+                "_wave_n_utterances": wave_ns,
+            }
+        variance[provider] = per_locale
+    return variance, warnings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--significance-path",
+        type=Path,
+        default=DEFAULT_SIG_PATH,
+        help=f"Path to results/significance.json (default: {DEFAULT_SIG_PATH.relative_to(REPO_ROOT)})",
+    )
+    parser.add_argument(
+        "--providers",
+        nargs="+",
+        default=DEFAULT_PROVIDERS,
+        help="Provider IDs to aggregate (default: all 5)",
+    )
+    parser.add_argument(
+        "--locales",
+        nargs="+",
+        default=DEFAULT_VARIANCE_LOCALES,
+        help="Locales for the variance block (default: en-US zh-CN)",
+    )
+    parser.add_argument(
+        "--waves",
+        nargs="+",
+        default=list(WAVE_PATHS.keys()),
+        help="Waves to include (default: a b c d)",
+    )
+    parser.add_argument(
+        "--allow-missing-waves",
+        action="store_true",
+        help="Compute mean/std on whatever waves are present (default: warn but continue)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the aggregated block but do not write significance.json",
+    )
+    args = parser.parse_args(argv)
+
+    variance, warnings = aggregate(
+        providers=args.providers,
+        locales=args.locales,
+        waves=args.waves,
+        require_all_waves=False,
+    )
+    for w in warnings:
+        print(w)
+
+    if args.dry_run:
+        print(json.dumps(variance, indent=2))
+        return 0
+
+    if not args.significance_path.is_file():
+        print(f"ERROR: {args.significance_path} not found")
+        return 2
+
+    with args.significance_path.open("r", encoding="utf-8") as f:
+        sig_doc = json.load(f)
+
+    sig_doc["variance"] = variance
+    sig_doc.setdefault("_note", {})
+    sig_doc["_note"]["variance"] = (
+        f"N={len(args.waves)} runs (waves {', '.join(args.waves)}); "
+        "includes provider transcription noise (prior block held transcripts fixed)."
+    )
+
+    with args.significance_path.open("w", encoding="utf-8") as f:
+        json.dump(sig_doc, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+    print(f"Wrote variance block to {args.significance_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_coverage.py
+++ b/scripts/check_coverage.py
@@ -1,0 +1,212 @@
+"""Hard-stop coverage gate for the fairness rollout.
+
+For a transcribed output directory (raw or variance-run), checks that:
+  1. The number of `<locale>/<utterance_id>.txt` files matches the
+     manifest's expected count for every locale we care about.
+  2. The `latency.json` file exists and its keyset (or
+     `measurements` keyset, for new-schema files) matches the
+     transcripts on disk exactly.
+
+If anything is off, prints the missing utterance IDs (set diff) and
+exits non-zero. NO retries, NO patching, NO filling in placeholders --
+the operator decides whether to investigate the provider API / network /
+keys before re-running the failing wave.
+
+Usage:
+    .venv/bin/python scripts/check_coverage.py <output_dir> --expected full
+    .venv/bin/python scripts/check_coverage.py <output_dir> --expected variance
+    .venv/bin/python scripts/check_coverage.py <output_dir> --locales en-US zh-CN
+
+`--expected full` checks all five locales (4,270 utts total).
+`--expected variance` checks en-US + zh-CN only (1,657 utts total).
+`--locales` overrides both with an explicit list.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MANIFEST = REPO_ROOT / "manifest.json"
+
+VARIANCE_LOCALES = ["en-US", "zh-CN"]
+
+
+def load_expected(manifest_path: Path) -> dict[str, set[str]]:
+    """Return {locale: set(utterance_ids)} from the manifest."""
+    with manifest_path.open("r", encoding="utf-8") as f:
+        manifest = json.load(f)
+    expected: dict[str, set[str]] = {}
+    for utt in manifest["utterances"]:
+        expected.setdefault(utt["locale"], set()).add(utt["id"])
+    return expected
+
+
+def collect_transcripts(output_dir: Path, locales: list[str]) -> dict[str, set[str]]:
+    """Return {locale: set(utterance_ids_with_a_txt_file)}."""
+    found: dict[str, set[str]] = {}
+    for locale in locales:
+        loc_dir = output_dir / locale
+        if not loc_dir.is_dir():
+            found[locale] = set()
+            continue
+        found[locale] = {p.stem for p in loc_dir.glob("*.txt")}
+    return found
+
+
+def collect_latency_keys(latency_path: Path) -> dict[str, set[str]] | None:
+    """Return {locale: set(utterance_ids)} from latency.json.
+
+    Accepts both the legacy flat schema and the new schema with
+    `measurements`. Returns None if the file is missing.
+    """
+    if not latency_path.is_file():
+        return None
+    with latency_path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    if isinstance(data, dict) and "measurements" in data:
+        keys = data["measurements"].keys()
+    else:
+        keys = data.keys()
+    by_locale: dict[str, set[str]] = {}
+    for key in keys:
+        if "/" not in key:
+            continue
+        locale, utt_id = key.split("/", 1)
+        by_locale.setdefault(locale, set()).add(utt_id)
+    return by_locale
+
+
+def check(
+    output_dir: Path,
+    locales: list[str],
+    expected: dict[str, set[str]],
+) -> int:
+    """Run the coverage check. Returns 0 on success, 1 on failure."""
+    print(f"Coverage gate: {output_dir}")
+    print(f"  Locales checked: {', '.join(locales)}")
+
+    found_transcripts = collect_transcripts(output_dir, locales)
+    latency_path = output_dir / "latency.json"
+    found_latency = collect_latency_keys(latency_path)
+
+    failures: list[str] = []
+    total_expected = 0
+    total_transcripts = 0
+    total_latency = 0
+
+    for locale in locales:
+        if locale not in expected:
+            failures.append(f"  [{locale}] NOT IN MANIFEST")
+            continue
+        exp_ids = expected[locale]
+        total_expected += len(exp_ids)
+
+        tx_ids = found_transcripts.get(locale, set())
+        total_transcripts += len(tx_ids)
+        missing_tx = exp_ids - tx_ids
+        extra_tx = tx_ids - exp_ids
+
+        print(
+            f"  [{locale}] transcripts: {len(tx_ids)}/{len(exp_ids)}"
+            + (f" MISSING={len(missing_tx)}" if missing_tx else "")
+            + (f" EXTRA={len(extra_tx)}" if extra_tx else "")
+        )
+        if missing_tx:
+            sample = sorted(missing_tx)[:10]
+            failures.append(f"  [{locale}] missing {len(missing_tx)} transcripts; first 10: {sample}")
+        if extra_tx:
+            sample = sorted(extra_tx)[:10]
+            failures.append(f"  [{locale}] extra {len(extra_tx)} transcripts not in manifest; first 10: {sample}")
+
+        if found_latency is None:
+            failures.append(f"  [{locale}] latency.json is MISSING (expected at {latency_path})")
+            continue
+        lat_ids = found_latency.get(locale, set())
+        total_latency += len(lat_ids)
+        missing_lat = exp_ids - lat_ids
+        extra_lat = lat_ids - exp_ids
+        tx_no_lat = tx_ids - lat_ids
+        lat_no_tx = lat_ids - tx_ids
+
+        print(
+            f"  [{locale}] latency:     {len(lat_ids)}/{len(exp_ids)}"
+            + (f" MISSING={len(missing_lat)}" if missing_lat else "")
+            + (f" EXTRA={len(extra_lat)}" if extra_lat else "")
+        )
+        if missing_lat:
+            sample = sorted(missing_lat)[:10]
+            failures.append(f"  [{locale}] missing {len(missing_lat)} latency entries; first 10: {sample}")
+        if tx_no_lat:
+            sample = sorted(tx_no_lat)[:10]
+            failures.append(f"  [{locale}] {len(tx_no_lat)} transcripts have no latency entry; first 10: {sample}")
+        if lat_no_tx:
+            sample = sorted(lat_no_tx)[:10]
+            failures.append(f"  [{locale}] {len(lat_no_tx)} latency entries have no transcript; first 10: {sample}")
+
+    print(
+        f"  TOTAL transcripts: {total_transcripts}/{total_expected}   TOTAL latency: {total_latency}/{total_expected}"
+    )
+
+    if failures:
+        print()
+        print("COVERAGE GATE FAILED. Do not proceed to scoring.")
+        for f in failures:
+            print(f)
+        print()
+        print(
+            "Per the rollout plan, we do NOT patch failures. Investigate the "
+            "provider API / network / keys, then re-run the failing wave from "
+            "scratch."
+        )
+        return 1
+
+    print("  OK -- coverage gate passed.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("output_dir", type=Path, help="Provider output directory (raw or variance run)")
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=DEFAULT_MANIFEST,
+        help=f"Path to manifest.json (default: {DEFAULT_MANIFEST.relative_to(REPO_ROOT)})",
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--expected",
+        choices=("full", "variance"),
+        help="Preset locale set: 'full' = all 5 locales (4,270 utts); 'variance' = en-US + zh-CN (1,657 utts)",
+    )
+    group.add_argument(
+        "--locales",
+        nargs="+",
+        help="Explicit locale list (overrides --expected)",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.output_dir.is_dir():
+        print(f"ERROR: output_dir does not exist: {args.output_dir}")
+        return 2
+    if not args.manifest.is_file():
+        print(f"ERROR: manifest not found: {args.manifest}")
+        return 2
+
+    expected = load_expected(args.manifest)
+    if args.locales:
+        locales = args.locales
+    elif args.expected == "variance":
+        locales = VARIANCE_LOCALES
+    else:
+        locales = sorted(expected.keys())
+
+    return check(args.output_dir, locales, expected)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/transcribe.py
+++ b/scripts/transcribe.py
@@ -1,9 +1,28 @@
 """Transcribe benchmark audio using provider batch APIs directly.
 
 Reads per-utterance .wav files and calls provider APIs with no middleware.
+Writes ``<output-dir>/<locale>/<utt_id>.txt`` per utterance, plus
+``<output-dir>/latency.json`` in the schema the leaderboard's strict
+validator expects:
+
+    {
+      "meta": {
+        "protocol": "batch",
+        "region": "<--region, default us-east-2>",
+        "clientLocation": "<--client-location>",
+        "concurrency": <--concurrency>,
+        "wrappedAt": "<isoformat utc>"
+      },
+      "measurements": {
+        "<locale>/<utt_id>": {"roundTripMs": <float>}
+      }
+    }
 
 Usage:
     python scripts/transcribe.py --provider deepgram-nova3 --output-dir submissions/raw/deepgram-nova3
+
+    # Pin region (defaults to us-east-2). Use --region us for Google Chirp-3.
+    python scripts/transcribe.py --provider google-chirp3 --output-dir submissions/raw/google-chirp3 --region us
 
     # Limit to one locale
     python scripts/transcribe.py --provider deepgram-nova3 --locale en-US --output-dir /tmp/test
@@ -15,6 +34,7 @@ Usage:
 import argparse
 import asyncio
 import base64
+import datetime
 import io
 import json
 import os
@@ -509,16 +529,45 @@ async def run_transcription(args):
         tasks = [process_one(item, session) for item in items]
         await asyncio.gather(*tasks)
 
-    # Merge with any existing latency data and write latency.json
+    # Write latency.json in the new schema (item 4 of the fairness-fixes
+    # plan): top-level ``meta`` block declaring protocol/region/etc., plus a
+    # ``measurements`` map keyed by ``"<locale>/<utt_id>"`` with per-entry
+    # ``{"roundTripMs": <float>}`` (batch). When the file already exists we
+    # merge new measurements into the previous run's so partial re-runs
+    # accumulate. Region defaults to ``us-east-2`` to match the published
+    # benchmark; pass ``--region us`` for Google Chirp-3 (multi-region) and
+    # any other provider whose model isn't routable via a single region.
+    new_measurements = {key: {"roundTripMs": ms} for key, ms in latency_records.items()}
     latency_path = output_dir / "latency.json"
     if latency_path.exists():
         with open(latency_path, "r", encoding="utf-8") as f:
             existing = json.load(f)
-        existing.update(latency_records)
-        latency_records = existing
+        if isinstance(existing, dict) and "measurements" in existing:
+            measurements = existing.get("measurements", {})
+            measurements.update(new_measurements)
+        else:
+            # Legacy flat schema on disk — migrate by wrapping its entries
+            # plus the new measurements into the new shape.
+            measurements = {k: {"roundTripMs": v} for k, v in (existing or {}).items() if isinstance(v, (int, float))}
+            measurements.update(new_measurements)
+    else:
+        measurements = new_measurements
+    out = {
+        "meta": {
+            "protocol": "batch",
+            "region": args.region,
+            "clientLocation": args.client_location,
+            "concurrency": args.concurrency,
+            "wrappedAt": datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds"),
+        },
+        "measurements": measurements,
+    }
     with open(latency_path, "w", encoding="utf-8") as f:
-        json.dump(latency_records, f, indent=2, ensure_ascii=False)
-    print(f"\nLatency recorded for {len(latency_records)} utterances -> {latency_path}")
+        json.dump(out, f, indent=2, ensure_ascii=False)
+    print(
+        f"\nLatency recorded for {len(measurements)} utterances "
+        f"(meta.protocol=batch meta.region={args.region}) -> {latency_path}"
+    )
 
     elapsed = time.time() - start_time
     print(f"Done. {completed} succeeded, {failed} failed in {elapsed:.1f}s")
@@ -548,6 +597,28 @@ def main():
         type=int,
         default=None,
         help="Resample audio to this sample rate before transcription (e.g. 8000)",
+    )
+    parser.add_argument(
+        "--region",
+        default="us-east-2",
+        help=(
+            "Server-side region label written to latency.json meta.region. Must be in "
+            "scoring/validate.py ALLOWED_LATENCY_REGIONS — currently the AWS-style names "
+            "(us-east-1, us-east-2, us-west-1, us-west-2, eu-west-1, eu-central-1, "
+            "ap-southeast-1, ap-northeast-1) plus the multi-region escapes 'us' and 'eu'. "
+            "Pass --region us for Google Chirp-3 (chirp_3 is only routable via the us "
+            "multi-region today). Default: us-east-2."
+        ),
+    )
+    parser.add_argument(
+        "--client-location",
+        default="aws:us-east-1",
+        help=(
+            "Free-text label describing where THIS process is running, written to "
+            "latency.json meta.clientLocation. Pin a single physical location for the "
+            "whole submission so cross-provider latency is comparable. Examples: "
+            "'aws:us-east-1', 'gcp:us-central1', 'SF macOS laptop, residential'."
+        ),
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary

Follow-ups from the scoring-fairness-fixes rollout (#22):

1. **`scripts/transcribe.py` writes `latency.json` in the new schema natively.** Submitters no longer need a separate wrap step; the strict validator accepts the output as-is. Adds `--region` (default `us-east-2`; pass `us` for Google Chirp-3) and `--client-location` so submitters declare the pinned measurement context up front.
2. **Promote `tmp/check_coverage.py` → `scripts/check_coverage.py`** — first-class submitter tool for verifying transcript + latency coverage against `manifest.json`. Hard-stop semantics.
3. **Promote `tmp/aggregate_variance.py` → `scripts/aggregate_variance.py`** — computes the N-wave variance block; will be re-run any time we add waves or providers.
4. **Delete `tmp/wrap_latency.py`** — obsolete now that `transcribe.py` emits the new schema natively.

## Schema details

`scripts/transcribe.py` now writes:

```json
{
  "meta": {
    "protocol": "batch",
    "region": "<--region, default us-east-2>",
    "clientLocation": "<--client-location>",
    "concurrency": <--concurrency>,
    "wrappedAt": "<isoformat utc>"
  },
  "measurements": {
    "<locale>/<utt_id>": {"roundTripMs": <float>}
  }
}
```

Existing `latency.json` files in either old or new schema are merged forward into the new shape, so partial re-runs accumulate.

## Test plan

- [x] `scripts/transcribe.py --help` shows the new `--region` and `--client-location` flags
- [x] Smoke run (1 conversation, en-US) writes a `meta` + `measurements` shaped file; `scoring/validate.py` reports `latency.json (new schema)` (other validation messages are about smoke being a partial run, not the schema)
- [x] `scripts/check_coverage.py` from new location passes coverage gate against `submissions/raw/deepgram-nova3`
- [x] `scripts/aggregate_variance.py --dry-run` computes the variance block correctly
- [x] `pytest tests/` passes (30/30)
- [x] `ruff format --check`, `ruff check`, `prettier --check`, `eslint` all pass
- [x] No published-data changes — rollout's `submissions/`, `results/`, `leaderboard/`, `paper.md` untouched

## Not in this PR (still owed)

- Push `scoring/prompts.py` to the `SCORING_PROMPTS_PY` GitHub secret so CI's post-merge re-scoring uses the locale-aware prompts (operator action only, can't be done from this PR).


Made with [Cursor](https://cursor.com)