### PR TITLE
Public-release prep: contact alias + accurate install instructions

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -24,7 +24,7 @@ Examples of unacceptable behavior:
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers at **soham@sierra.ai**. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers at **research@sierra.ai**. All complaints will be reviewed and investigated promptly and fairly.
 
 ## Attribution
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The audio is hosted as a gated dataset on HuggingFace. You'll need to:
 
 ```bash
 export HF_TOKEN=your_token_here
-pip install -r scripts/requirements.txt
+pip install -e ".[tools]"
 python scripts/download_audio.py
 ```
 
@@ -103,11 +103,11 @@ Results are posted as a comment on your PR and added to the leaderboard on merge
 
 ```
 manifest.json              # Audio file list + ground truth transcripts
+pyproject.toml             # Python deps: base + [tools], [scoring], [transcribe] extras
 scripts/
-  download_audio.py        # Download audio from HuggingFace
-  transcribe.py            # Runs provider APIs to generate transcripts + latency
+  download_audio.py        # Download audio from HuggingFace (requires [tools])
+  transcribe.py            # Runs provider APIs to generate transcripts + latency (requires [transcribe])
   latency_stats.py         # Compute p50/p95 latency from latency.json files
-  requirements.txt         # Python dependencies
 submissions/
   SUBMITTING.md            # Full submission contract
   raw/                     # Raw transcripts + latency.json, one directory per provider
@@ -117,12 +117,23 @@ scoring/
   normalize.py             # LLM-based transcript normalization
   score.py                 # Metrics computation (corpus WER, sig. WER)
   metrics.py               # Core metric implementations
-  prompts.py               # ⚠️ Gitignored — injected from GitHub secret in CI
+  prompts.py               # Gitignored — injected from GitHub secret in CI
 results/
   leaderboard.json         # Aggregated leaderboard data
   <provider>/scores.json   # Per-provider score breakdowns (includes latency)
 leaderboard/               # React/Vite leaderboard web app
 .github/workflows/         # CI for validation, scoring, and deployment
+```
+
+### Installing dependencies
+
+The project uses `pyproject.toml` with three optional extras:
+
+```bash
+pip install -e .                # base: just the validator (pyyaml)
+pip install -e ".[tools]"       # + huggingface-hub, requests (for download_audio.py)
+pip install -e ".[scoring]"     # + jiwer, openai (maintainers; needs scoring/prompts.py)
+pip install -e ".[transcribe]"  # + provider SDKs (for running scripts/transcribe.py)
 ```
 
 ## Citing MU-Bench

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 If you discover a security vulnerability in this project, please report it responsibly:
 
 1. **Do not** open a public GitHub issue.
-2. Email **soham@sierra.ai** with a description of the vulnerability, steps to reproduce, and any relevant details.
+2. Email **research@sierra.ai** with a description of the vulnerability, steps to reproduce, and any relevant details.
 3. We will acknowledge receipt within 48 hours and provide an estimated timeline for a fix.
 
 ## Scope

--- a/leaderboard/src/App.jsx
+++ b/leaderboard/src/App.jsx
@@ -104,8 +104,8 @@ export default function App() {
                 <div className="footer-inner">
                     <p className="footer-contact">
                         For questions or feedback, contact{" "}
-                        <a href="mailto:soham@sierra.ai" className="footer-email">
-                            soham@sierra.ai
+                        <a href="mailto:research@sierra.ai" className="footer-email">
+                            research@sierra.ai
                         </a>
                     </p>
                 </div>


### PR DESCRIPTION
## Summary

Two small cleanups identified in a pre-public-release audit. Neither changes how anything works.

- **Maintainer contact → shared alias.** Swap `soham@sierra.ai` for `research@sierra.ai` in the three places it's exposed publicly: `SECURITY.md`, `CODE_OF_CONDUCT.md`, and the leaderboard footer (`leaderboard/src/App.jsx`). Personal addresses on a public repo are a maintenance hazard; the alias survives staffing changes.
- **README install instructions are accurate again.** `pip install -r scripts/requirements.txt` referenced a file that no longer exists (deps moved to `pyproject.toml` extras). Replaced with `pip install -e \".[tools]\"` in step 2, dropped the stale `requirements.txt` line from the Repository Structure block, and added a small \"Installing dependencies\" subsection that documents all four extras (base / `[tools]` / `[scoring]` / `[transcribe]`) so newcomers know which one they actually need.

## Out of scope (deliberately)

- Branch protection on `main` was tightened separately (`require_last_push_approval: true`) via the GitHub API; not in this diff.
- Two further protections we discussed (`enforce_admins: true`, `required_conversation_resolution: true`) are pending a separate decision because they affect maintainer hotfix flow.
- Key rotation in the local \`.env\` and the \`scoring\` GitHub environment is a separate operational task (no code change).

## Test plan

- [ ] CI lint + JS lint/prettier pass (verified locally with \`prek\` and \`npx eslint/prettier\`)
- [ ] \`grep -rn soham@sierra leaderboard/src\` returns nothing (already confirmed; the only remaining hit is in the gitignored \`leaderboard/dist/\` build artifact, which the deploy workflow rebuilds from source)
- [ ] Visually confirm the leaderboard footer renders \`research@sierra.ai\` in dev (\`cd leaderboard && npm run dev\`)
- [ ] README's step 2 install command works end-to-end on a clean venv (\`python -m venv .venv && .venv/bin/pip install -e \".[tools]\"\`)

Made with [Cursor](https://cursor.com)