### PR TITLE
Switch maintainer contact to research@sierra.ai

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -24,7 +24,7 @@ Examples of unacceptable behavior:
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers at **soham@sierra.ai**. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers at **research@sierra.ai**. All complaints will be reviewed and investigated promptly and fairly.
 
 ## Attribution
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 If you discover a security vulnerability in this project, please report it responsibly:
 
 1. **Do not** open a public GitHub issue.
-2. Email **soham@sierra.ai** with a description of the vulnerability, steps to reproduce, and any relevant details.
+2. Email **research@sierra.ai** with a description of the vulnerability, steps to reproduce, and any relevant details.
 3. We will acknowledge receipt within 48 hours and provide an estimated timeline for a fix.
 
 ## Scope

--- a/leaderboard/src/App.jsx
+++ b/leaderboard/src/App.jsx
@@ -104,8 +104,8 @@ export default function App() {
                 <div className="footer-inner">
                     <p className="footer-contact">
                         For questions or feedback, contact{" "}
-                        <a href="mailto:soham@sierra.ai" className="footer-email">
-                            soham@sierra.ai
+                        <a href="mailto:research@sierra.ai" className="footer-email">
+                            research@sierra.ai
                         </a>
                     </p>
                 </div>


### PR DESCRIPTION
## Summary

Flips the public-facing maintainer contact from \`soham@sierra.ai\` back to \`research@sierra.ai\` across:

- \`SECURITY.md\` — vulnerability reporting address
- \`CODE_OF_CONDUCT.md\` — conduct violation reporting address
- \`leaderboard/src/App.jsx\` — footer mailto link + display text rendered at research.sierra.ai/mubench

The \`research@sierra.ai\` alias is now routing, so we can move off the personal address before flipping the repo public. A shared alias is preferable to a personal one on a public repo — it survives staffing changes and distributes inbound load.

## Context

This reverses commit \`f2606a663\` (the emergency revert earlier today that flipped contacts back to \`soham@sierra.ai\` because the alias wasn't yet routing). Original intent was \`research@sierra.ai\` via #27; this PR restores that.

## Test plan

- [ ] CI lint + JS lint/prettier pass
- [ ] \`grep -rn soham@sierra\` in the three touched files returns nothing
- [ ] Visually confirm the leaderboard footer renders \`research@sierra.ai\` in dev (\`cd leaderboard && npm run dev\`)
- [ ] Once merged and deployed, click the footer mailto to confirm it opens with \`research@sierra.ai\` in the \"To\" field

Made with [Cursor](https://cursor.com)