### PR TITLE
Cache results/details/ across /score and post-merge-score

### DIFF
--- a/.github/workflows/post-merge-score.yml
+++ b/.github/workflows/post-merge-score.yml
@@ -129,6 +129,28 @@ jobs:
             --judge-seed 7 \
             --manifest-gold-hash-file submissions/normalized/_gold/manifest_gold_hash.txt
 
+      # Reuse per-utterance significance/WER results from the preceding
+      # /score run on this PR. Invalidation drops only detail files whose
+      # normalized prediction hash changed, so an identical post-merge
+      # tree inherits all of /score's LLM work.
+      - name: Restore results cache
+        uses: actions/cache@v4
+        with:
+          path: results/${{ steps.detect.outputs.name }}
+          key: results-v1-${{ steps.detect.outputs.name }}-${{ github.event.pull_request.number }}-${{ github.event.pull_request.merge_commit_sha }}
+          restore-keys: |
+            results-v1-${{ steps.detect.outputs.name }}-${{ github.event.pull_request.number }}-
+
+      - name: Invalidate stale results
+        run: |
+          python scripts/invalidate_results_cache.py invalidate \
+            --normalized-dir "submissions/normalized/${{ steps.detect.outputs.name }}" \
+            --results-dir "results/${{ steps.detect.outputs.name }}" \
+            --judge-model gpt-4.1-2025-04-14 \
+            --judge-temperature 0.0 \
+            --judge-seed 7 \
+            --manifest-gold-hash-file submissions/normalized/_gold/manifest_gold_hash.txt
+
       - name: Calculate metrics
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -142,6 +164,16 @@ jobs:
             --manifest manifest.json \
             --output-dir "results/${{ steps.detect.outputs.name }}" \
             --num-workers 25
+
+      - name: Update results cache metadata
+        run: |
+          python scripts/invalidate_results_cache.py update \
+            --normalized-dir "submissions/normalized/${{ steps.detect.outputs.name }}" \
+            --results-dir "results/${{ steps.detect.outputs.name }}" \
+            --judge-model gpt-4.1-2025-04-14 \
+            --judge-temperature 0.0 \
+            --judge-seed 7 \
+            --manifest-gold-hash-file submissions/normalized/_gold/manifest_gold_hash.txt
 
       - name: Merge latency statistics into scores.json
         run: |

--- a/.github/workflows/score-submission.yml
+++ b/.github/workflows/score-submission.yml
@@ -204,6 +204,29 @@ jobs:
             --judge-seed 7 \
             --manifest-gold-hash-file submissions/normalized/_gold/manifest_gold_hash.txt
 
+      # Reuse per-utterance significance/WER results from prior runs on
+      # this PR (including the later post-merge run, which shares the
+      # same cache prefix). Invalidation drops only detail files whose
+      # normalized prediction hash changed, so a re-/score on unchanged
+      # content skips almost all LLM work.
+      - name: Restore results cache
+        uses: actions/cache@v4
+        with:
+          path: results/${{ steps.detect.outputs.name }}
+          key: results-v1-${{ steps.detect.outputs.name }}-${{ needs.gate.outputs.pr_number }}-${{ steps.prhead.outputs.sha }}
+          restore-keys: |
+            results-v1-${{ steps.detect.outputs.name }}-${{ needs.gate.outputs.pr_number }}-
+
+      - name: Invalidate stale results
+        run: |
+          python scripts/invalidate_results_cache.py invalidate \
+            --normalized-dir "submissions/normalized/${{ steps.detect.outputs.name }}" \
+            --results-dir "results/${{ steps.detect.outputs.name }}" \
+            --judge-model gpt-4.1-2025-04-14 \
+            --judge-temperature 0.0 \
+            --judge-seed 7 \
+            --manifest-gold-hash-file submissions/normalized/_gold/manifest_gold_hash.txt
+
       - name: Calculate metrics
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -217,6 +240,16 @@ jobs:
             --manifest manifest.json \
             --output-dir "results/${{ steps.detect.outputs.name }}" \
             --num-workers 25
+
+      - name: Update results cache metadata
+        run: |
+          python scripts/invalidate_results_cache.py update \
+            --normalized-dir "submissions/normalized/${{ steps.detect.outputs.name }}" \
+            --results-dir "results/${{ steps.detect.outputs.name }}" \
+            --judge-model gpt-4.1-2025-04-14 \
+            --judge-temperature 0.0 \
+            --judge-seed 7 \
+            --manifest-gold-hash-file submissions/normalized/_gold/manifest_gold_hash.txt
 
       - name: Merge latency statistics into scores.json
         run: |

--- a/scripts/invalidate_results_cache.py
+++ b/scripts/invalidate_results_cache.py
@@ -1,0 +1,171 @@
+"""Per-file cache invalidation for `results/<name>/details/`.
+
+Companion to `invalidate_normalized_cache.py`. `scoring.score` already
+skips per-utterance metrics whose cached `details/<locale>/<uid>.json`
+entry has `wer` / `significantWer` set, so we just have to prune only
+the detail files whose normalized prediction (or gold) changed.
+
+Subcommands:
+  invalidate  If judge config or manifest gold hash changed, wipe. Else
+              delete `details/<locale>/<uid>.json` for any utterance
+              whose normalized prediction file hash changed since the
+              last cache write.
+  update      After `scoring.score` succeeds, record the current
+              normalized prediction hashes and invariants so the next
+              run can diff against them.
+
+Cache metadata lives at `<results-dir>/.cache_meta.json` and is cached
+alongside `details/` and `scores.json`.
+"""
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+META_FILENAME = ".cache_meta.json"
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    h.update(path.read_bytes())
+    return h.hexdigest()
+
+
+def _enumerate_normalized(normalized_dir: Path):
+    for locale_dir in sorted(normalized_dir.iterdir()):
+        if not locale_dir.is_dir() or locale_dir.name.startswith("_"):
+            continue
+        for txt in sorted(locale_dir.glob("*.txt")):
+            yield locale_dir.name, txt.stem, _sha256_file(txt)
+
+
+def _current_files(normalized_dir: Path) -> dict:
+    return {f"{locale}/{uid}": h for locale, uid, h in _enumerate_normalized(normalized_dir)}
+
+
+def _wipe(results_dir: Path) -> None:
+    if not results_dir.exists():
+        return
+    details_dir = results_dir / "details"
+    if details_dir.exists():
+        for p in details_dir.rglob("*.json"):
+            p.unlink()
+    for name in ("scores.json", META_FILENAME):
+        p = results_dir / name
+        if p.exists():
+            p.unlink()
+
+
+def cmd_invalidate(args) -> None:
+    meta_path = args.results_dir / META_FILENAME
+    if not args.results_dir.exists() or not meta_path.exists():
+        print("No prior results cache; full scoring will run.")
+        return
+
+    try:
+        cached = json.loads(meta_path.read_text(encoding="utf-8"))
+    except Exception as e:
+        print(f"Results cache metadata invalid ({e}); wiping.")
+        _wipe(args.results_dir)
+        return
+
+    current_judge = {
+        "model": args.judge_model,
+        "temperature": args.judge_temperature,
+        "seed": args.judge_seed,
+    }
+    if cached.get("judge") != current_judge:
+        print("Judge config changed; wiping results cache.")
+        _wipe(args.results_dir)
+        return
+    if cached.get("manifestGoldHash") != args.manifest_gold_hash:
+        print("Manifest gold hash changed; wiping results cache.")
+        _wipe(args.results_dir)
+        return
+
+    current = _current_files(args.normalized_dir)
+    cached_files = cached.get("normalizedFiles", {})
+    details_dir = args.results_dir / "details"
+
+    changed = 0
+    removed = 0
+    for key, current_hash in current.items():
+        if cached_files.get(key) != current_hash:
+            detail_path = details_dir / f"{key}.json"
+            if detail_path.exists():
+                detail_path.unlink()
+                changed += 1
+    for key in cached_files:
+        if key not in current:
+            detail_path = details_dir / f"{key}.json"
+            if detail_path.exists():
+                detail_path.unlink()
+                removed += 1
+
+    # scores.json is rebuilt from details each run, but if ANY detail was
+    # invalidated we blow it away to avoid a stale aggregate hanging around
+    # if score.py short-circuits on error.
+    if changed or removed:
+        scores_path = args.results_dir / "scores.json"
+        if scores_path.exists():
+            scores_path.unlink()
+
+    retained = sum(1 for key in current if (details_dir / f"{key}.json").exists())
+    print(
+        f"Results cache hit. {changed} detail(s) invalidated (normalized changed), "
+        f"{removed} stale entries removed, {retained} retained."
+    )
+
+
+def cmd_update(args) -> None:
+    args.results_dir.mkdir(parents=True, exist_ok=True)
+    meta = {
+        "judge": {
+            "model": args.judge_model,
+            "temperature": args.judge_temperature,
+            "seed": args.judge_seed,
+        },
+        "manifestGoldHash": args.manifest_gold_hash,
+        "normalizedFiles": _current_files(args.normalized_dir),
+    }
+    meta_path = args.results_dir / META_FILENAME
+    meta_path.write_text(
+        json.dumps(meta, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(f"Wrote {meta_path} ({len(meta['normalizedFiles'])} normalized files hashed).")
+
+
+def _add_common(p):
+    p.add_argument("--normalized-dir", type=Path, required=True)
+    p.add_argument("--results-dir", type=Path, required=True)
+    p.add_argument("--judge-model", required=True)
+    p.add_argument("--judge-temperature", required=True)
+    p.add_argument("--judge-seed", required=True)
+    p.add_argument("--manifest-gold-hash-file", type=Path, required=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    _add_common(sub.add_parser("invalidate"))
+    _add_common(sub.add_parser("update"))
+    args = parser.parse_args()
+
+    if not args.manifest_gold_hash_file.exists():
+        print(f"ERROR: manifest gold hash file missing: {args.manifest_gold_hash_file}")
+        sys.exit(1)
+    args.manifest_gold_hash = args.manifest_gold_hash_file.read_text(encoding="utf-8").strip()
+    args.normalized_dir = args.normalized_dir.resolve()
+    args.results_dir = args.results_dir.resolve()
+
+    if args.cmd == "invalidate":
+        cmd_invalidate(args)
+    elif args.cmd == "update":
+        cmd_update(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Mirrors the normalized cache added in #30 (commit e04bb1d), so when post-merge-score runs on content byte-identical to the preceding `/score`, the Calculate-metrics LLM pass is a no-op.

- New `scripts/invalidate_results_cache.py` tracks normalized-prediction hashes in `results/<name>/.cache_meta.json` and deletes only the `results/<name>/details/<locale>/<uid>.json` files whose upstream normalized prediction changed.
- Judge-config or manifest-gold-hash change wipes the whole results cache.
- `scoring.score` already skips utterances whose cached detail file has `wer` / `significantWer` populated (lines 433-516), so no Python changes needed.
- `score-submission.yml` and `post-merge-score.yml` both get restore/invalidate/update steps around `Calculate metrics`, keyed the same way as the normalize cache.

## Test plan

- [x] Ruff format clean
- [ ] Merge, then on next submission PR: `/score` populates cache; post-merge-score restores and reports "Results cache hit. 0 invalidated" in the `Invalidate stale results` step
- [ ] Edit a .txt mid-PR and confirm only the affected detail file is invalidated