### PR TITLE
Fix post-merge-score push: use custom GitHub App token instead of default GITHUB_TOKEN

### DIFF
--- a/.github/workflows/post-merge-score.yml
+++ b/.github/workflows/post-merge-score.yml
@@ -19,8 +19,22 @@ jobs:
     runs-on: ubuntu-latest
     environment: scoring
     steps:
+      # Mint a short-lived installation token for the mu-bench-post-merge
+      # GitHub App. The final "Commit results to main" push then runs as
+      # the app, which is in the ruleset's bypass list — without this the
+      # default GITHUB_TOKEN (github-actions[bot]) gets GH006 rejections,
+      # because bots can't be added to classic branch-protection bypass
+      # and sierra-research's policy doesn't permit PAT-based auth.
+      - name: Mint app installation token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.MU_BENCH_APP_ID }}
+          private-key: ${{ secrets.MU_BENCH_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
+          token: ${{ steps.app-token.outputs.token }}
           ref: main
           fetch-depth: 0
 
@@ -157,9 +171,14 @@ jobs:
         run: python -m scoring.update_leaderboard
 
       - name: Commit results to main
+        env:
+          # Look up the app's bot user id once so commits are attributed
+          # to the app (shows as "mu-bench-post-merge[bot]" in git log)
+          # instead of leaving the default identity from the previous step.
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
           # Commit canonical gold cache too — it's a per-repo artifact and
           # its hash feeds scores.json cache invalidation.
           git add results/ submissions/normalized/


### PR DESCRIPTION
## Summary

Fixes the known `GH006: Protected branch update failed` rejection on every `post-merge-score.yml` run (observed on PR #25 and PR #30). Default `GITHUB_TOKEN` runs as `github-actions[bot]`, which isn't listable as a bypass actor in this repo's ruleset. `sierra-research` org policy disallows PAT-based auth, so we authenticate as a custom GitHub App (`mu-bench-post-merge`) that IS in the ruleset bypass.

## How it works

1. `actions/create-github-app-token@v1` mints a short-lived installation token (~10 min lifetime) from the App ID and private key stored as repo secrets.
2. `actions/checkout@v4` uses that token — all subsequent git ops (including the final push) inherit it via the stored credential.
3. `git config user.name/email` sets commits to be authored by the app's bot identity (`mu-bench-post-merge[bot]`) so history is clearly attributed.

## Prereqs (must be in place before merging)

- [x] Custom GitHub App `mu-bench-post-merge` created under `sierra-research`, installed on `mu-bench` with `Contents: Read and write`.
- [ ] Secrets `MU_BENCH_APP_ID` and `MU_BENCH_APP_PRIVATE_KEY` exist at repo level.
- [ ] Ruleset on `main` has the `mu-bench-post-merge` app in the bypass list.

## Test plan

- [ ] After merge, re-run the failed post-merge-score run (24691143357) with `gh run rerun --failed` and verify the `Commit results to main` step succeeds.
- [ ] `results/pipeline-smoke-test/` and `submissions/normalized/pipeline-smoke-test/` land on `main`.
- [ ] Commit author in `git log` shows as `mu-bench-post-merge[bot]`.
- [ ] `deploy-leaderboard.yml` fires and the synthetic row appears on the live site.

## Non-changes

- `score-submission.yml` does NOT push (only posts PR comments via `pull-requests: write`), so it keeps the default token.