### PR TITLE
Test: retrigger post-merge-score to verify PR #33 push fix

### DIFF
--- a/submissions/raw/pipeline-smoke-test/metadata.yaml
+++ b/submissions/raw/pipeline-smoke-test/metadata.yaml
@@ -9,4 +9,4 @@ config:
   noiseSuppression: default
   domainAdaptation: default
   keywordBoosting: default
-notes: 'Synthetic pipeline validation test. Every transcript is the literal string "pipeline smoke test"; latency is a constant placeholder. Not a real transcription system. To be reverted after pipeline verification.'
+notes: 'Synthetic pipeline validation test. Every transcript is the literal string "pipeline smoke test"; latency is a constant placeholder. Not a real transcription system. Retriggered 2026-04-21 to verify the GitHub App push fix from PR #33 — normalize cache should restore from the prior failed run so scoring only re-does the final push. To be reverted after pipeline verification.'


### PR DESCRIPTION
## Summary

Trivial metadata.yaml note update on `pipeline-smoke-test` to retrigger `post-merge-score.yml` now that the custom GitHub App push fix (PR #33) is on main.

The prior post-merge run (24691143357) failed at the `Commit results to main` step with GH006. The rest of the pipeline (all LLM steps, cache save) completed successfully. This PR's merge re-fires post-merge-score with:

- ✅ GitHub App token auth for the final push (PR #33)
- ✅ Normalize cache from the failed run's save → all 4265 non-empty utterances already normalized → normalize step should be a no-op
- ❌ No results cache yet (PR #32 still open) → Calculate metrics still runs full significance-scoring pass

## Test plan

- [ ] Merge fires `post-merge-score.yml`.
- [ ] `Restore normalized cache` reports `0 invalidated`.
- [ ] `Normalize submissions` logs `All files already normalized`.
- [ ] `Calculate metrics` runs the ~5-8 min significance-scoring pass.
- [ ] `Commit results to main` **succeeds** (the gold test — app token push).
- [ ] `results/pipeline-smoke-test/scores.json` lands on main.
- [ ] `deploy-leaderboard.yml` fires and `research.sierra.ai/mubench/` shows the Pipeline Smoke Test row.

## Cleanup

This PR and the underlying `pipeline-smoke-test` submission will be reverted together in a follow-up once end-to-end verification is confirmed.