### PR TITLE
Post interim phase progress on /score PR comment (fixes #31)

### DIFF
--- a/.github/workflows/score-submission.yml
+++ b/.github/workflows/score-submission.yml
@@ -163,6 +163,19 @@ jobs:
           SCORING_SEED: "7"
         run: python -m scoring.normalize_gold --manifest manifest.json
 
+      - name: Update progress — phase 2 of 4
+        if: steps.progress.outputs.comment_id
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: ${{ steps.progress.outputs.comment_id }},
+              body: `## ⏳ Scoring in progress — normalizing\n\n- ✅ Gold cache refreshed\n- 🔄 **Normalizing submission predictions** (~7 min for a 5-locale submission at 25 workers)\n- ⏳ Per-error significance classification\n- ⏳ Latency stats + leaderboard\n\nFollow live progress in the [workflow logs](${runUrl}).`,
+            });
+
       - name: Restore normalized cache
         uses: actions/cache@v4
         with:
@@ -203,6 +216,19 @@ jobs:
             --judge-temperature 0.0 \
             --judge-seed 7 \
             --manifest-gold-hash-file submissions/normalized/_gold/manifest_gold_hash.txt
+
+      - name: Update progress — phase 3 of 4
+        if: steps.progress.outputs.comment_id
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: ${{ steps.progress.outputs.comment_id }},
+              body: `## ⏳ Scoring in progress — scoring errors\n\n- ✅ Gold cache refreshed\n- ✅ Normalization complete\n- 🔄 **Classifying per-utterance alignment errors** (~8–12 min for a 5-locale submission at 25 workers)\n- ⏳ Latency stats + leaderboard\n\nFollow live progress in the [workflow logs](${runUrl}).`,
+            });
 
       # Reuse per-utterance significance/WER results from prior runs on
       # this PR (including the later post-merge run, which shares the
@@ -250,6 +276,19 @@ jobs:
             --judge-temperature 0.0 \
             --judge-seed 7 \
             --manifest-gold-hash-file submissions/normalized/_gold/manifest_gold_hash.txt
+
+      - name: Update progress — phase 4 of 4
+        if: steps.progress.outputs.comment_id
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: ${{ steps.progress.outputs.comment_id }},
+              body: `## ⏳ Scoring in progress — finalizing\n\n- ✅ Gold cache refreshed\n- ✅ Normalization complete\n- ✅ Error classification complete\n- 🔄 **Writing latency stats and updating leaderboard**\n\nFollow live progress in the [workflow logs](${runUrl}).`,
+            });
 
       - name: Merge latency statistics into scores.json
         run: |


### PR DESCRIPTION
## Summary

Adds three phase-bump steps to `score-submission.yml` so the `⏳ Scoring in progress` PR comment reflects the current phase throughout the ~15-20 min scoring pipeline. Before this, maintainers either had to click through to the workflow log or wait for the final results comment to know whether anything was progressing.

Closes #31.

## How it works

Between existing LLM-heavy steps, three new `actions/github-script` steps update the comment body in place using `steps.progress.outputs.comment_id`:

| After step | New comment state |
|---|---|
| `Refresh canonical gold cache` | Phase 2/4: normalizing |
| `Update normalized cache metadata` | Phase 3/4: scoring errors |
| `Update results cache metadata` | Phase 4/4: finalizing |

Each update keeps the live-log link and uses a ✅/🔄/⏳ checklist so readers can see what's done, what's running, and what's left at a glance. The final `Post results comment` step unchanged — it still replaces the comment with the WER/UER results table.

## Test plan

Exercised end-to-end by the upcoming streamlined lifecycle validation (single-locale synthetic submission). The expected sequence on the PR comment:

1. Initial: "⏳ Scoring in progress — pipeline starting"
2. After ~1 min: "⏳ Scoring in progress — normalizing"
3. After ~3–8 min: "⏳ Scoring in progress — scoring errors"
4. After ~8–15 min: "⏳ Scoring in progress — finalizing"
5. Final: "Scoring Results for <model>" with WER/UER table