### PR TITLE
Repoint research.sierra.ai root + /taubench

### DIFF
--- a/.github/workflows/deploy-leaderboard.yml
+++ b/.github/workflows/deploy-leaderboard.yml
@@ -50,11 +50,27 @@ jobs:
           mkdir -p site/mubench
           cp -r leaderboard/dist/* site/mubench/
           echo "research.sierra.ai" > site/CNAME
+          # Root: redirect to Sierra's research landing page
           cat > site/index.html << 'REDIRECT'
           <!DOCTYPE html>
           <html>
-            <head><meta http-equiv="refresh" content="0; url=/mubench/" /></head>
-            <body><a href="/mubench/">Redirecting to mubench...</a></body>
+            <head>
+              <meta http-equiv="refresh" content="0; url=https://sierra.ai/resources/research" />
+              <link rel="canonical" href="https://sierra.ai/resources/research" />
+            </head>
+            <body><a href="https://sierra.ai/resources/research">Redirecting to sierra.ai/resources/research...</a></body>
+          </html>
+          REDIRECT
+          # /taubench: redirect to taubench.com
+          mkdir -p site/taubench
+          cat > site/taubench/index.html << 'REDIRECT'
+          <!DOCTYPE html>
+          <html>
+            <head>
+              <meta http-equiv="refresh" content="0; url=https://taubench.com" />
+              <link rel="canonical" href="https://taubench.com" />
+            </head>
+            <body><a href="https://taubench.com">Redirecting to taubench.com...</a></body>
           </html>
           REDIRECT
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Multilingual Utterances Transcription Benchmark — an open benchmark for evaluating speech-to-text providers across multiple locales and metrics.
 
-**[Leaderboard](https://research.sierra.ai)** · **[Dataset](https://huggingface.co/datasets/sierra-research/mu-bench)** · **[Blog](https://research.sierra.ai/mubench/#paper)**
+**[Leaderboard](https://research.sierra.ai/mubench)** · **[Dataset](https://huggingface.co/datasets/sierra-research/mu-bench)** · **[Blog](https://research.sierra.ai/mubench/#paper)**
 
 ## Overview
 

--- a/leaderboard/public/paper.md
+++ b/leaderboard/public/paper.md
@@ -203,7 +203,7 @@ We're expanding MU-Bench to more locales — we benchmark 42 languages internall
 
 - **Dataset**: [`sierra-research/mu-bench`](https://huggingface.co/datasets/sierra-research/mu-bench) on HuggingFace
 - **Code & submissions**: [github.com/sierra-research/mu-bench](https://github.com/sierra-research/mu-bench)
-- **Leaderboard**: [research.sierra.ai](https://research.sierra.ai)
+- **Leaderboard**: [research.sierra.ai/mubench](https://research.sierra.ai/mubench)
 
 ---
 


### PR DESCRIPTION
## Summary

The research.sierra.ai subdomain is meant to be the home of multiple Sierra research artifacts, not just mu-bench. This PR reshapes the routing without taking anything down:

| Path | Before | After |
|---|---|---|
| \`research.sierra.ai/mubench/\` | Leaderboard | Leaderboard (unchanged) |
| \`research.sierra.ai/\` | Redirect to \`/mubench/\` | Redirect to \`https://sierra.ai/resources/research\` |
| \`research.sierra.ai/taubench\` | 404 | Redirect to \`https://taubench.com\` |