### PR TITLE
Add Sierra favicon to leaderboard + widget tab headers

### DIFF
--- a/leaderboard/index.html
+++ b/leaderboard/index.html
@@ -1,12 +1,13 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>&mu;-bench: Multilingual Utterances Transcription Benchmark</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
-  </body>
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link rel="icon" type="image/jpeg" href="%BASE_URL%sierra_logo.jpeg" />
+        <title>&mu;-bench: Multilingual Utterances Transcription Benchmark</title>
+    </head>
+    <body>
+        <div id="root"></div>
+        <script type="module" src="/src/main.jsx"></script>
+    </body>
 </html>

--- a/leaderboard/widgets/audio-samples/index.html
+++ b/leaderboard/widgets/audio-samples/index.html
@@ -1,8 +1,9 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link rel="icon" type="image/jpeg" href="%BASE_URL%sierra_logo.jpeg" />
         <title>μ-bench widget: audio-samples</title>
     </head>
     <body>

--- a/leaderboard/widgets/coverage-matrix/index.html
+++ b/leaderboard/widgets/coverage-matrix/index.html
@@ -1,8 +1,9 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link rel="icon" type="image/jpeg" href="%BASE_URL%sierra_logo.jpeg" />
         <title>μ-bench widget: coverage-matrix</title>
     </head>
     <body>

--- a/leaderboard/widgets/dataset-stats/index.html
+++ b/leaderboard/widgets/dataset-stats/index.html
@@ -1,8 +1,9 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link rel="icon" type="image/jpeg" href="%BASE_URL%sierra_logo.jpeg" />
         <title>μ-bench widget: dataset-stats</title>
     </head>
     <body>

--- a/leaderboard/widgets/error-examples/index.html
+++ b/leaderboard/widgets/error-examples/index.html
@@ -1,8 +1,9 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link rel="icon" type="image/jpeg" href="%BASE_URL%sierra_logo.jpeg" />
         <title>μ-bench widget: error-examples</title>
     </head>
     <body>

--- a/leaderboard/widgets/globe/index.html
+++ b/leaderboard/widgets/globe/index.html
@@ -1,8 +1,9 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link rel="icon" type="image/jpeg" href="%BASE_URL%sierra_logo.jpeg" />
         <title>μ-bench widget: globe</title>
     </head>
     <body>

--- a/leaderboard/widgets/heatmap/index.html
+++ b/leaderboard/widgets/heatmap/index.html
@@ -1,8 +1,9 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link rel="icon" type="image/jpeg" href="%BASE_URL%sierra_logo.jpeg" />
         <title>μ-bench widget: heatmap</title>
     </head>
     <body>

--- a/leaderboard/widgets/radar/index.html
+++ b/leaderboard/widgets/radar/index.html
@@ -1,8 +1,9 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link rel="icon" type="image/jpeg" href="%BASE_URL%sierra_logo.jpeg" />
         <title>μ-bench widget: radar</title>
     </head>
     <body>

--- a/leaderboard/widgets/significance/index.html
+++ b/leaderboard/widgets/significance/index.html
@@ -1,8 +1,9 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link rel="icon" type="image/jpeg" href="%BASE_URL%sierra_logo.jpeg" />
         <title>μ-bench widget: significance</title>
     </head>
     <body>


### PR DESCRIPTION
## Summary

Browser tabs for research.sierra.ai/mubench and the embeddable widget pages showed the default globe icon instead of the Sierra logo. This adds a \`<link rel=\"icon\">\` pointing at the already-bundled \`leaderboard/public/sierra_logo.jpeg\`.

Touches:
- \`leaderboard/index.html\` (main app)
- \`leaderboard/widgets/*/index.html\` (all 8 widget entry points)

Uses Vite's \`%BASE_URL%\` HTML substitution so the href resolves correctly in both local dev (\`/\`) and the deployed Pages build (\`/mubench/\`).