### PR TITLE
Deploy the leaderboard from post-merge scoring, not a push path filter

### DIFF
--- a/.github/workflows/deploy-leaderboard.yml
+++ b/.github/workflows/deploy-leaderboard.yml
@@ -7,6 +7,20 @@ on:
     paths:
       - "leaderboard/**"
       - "results/leaderboard.json"
+  # Called by post-merge-score.yml once scoring results land on main. The
+  # push trigger above can't be relied on for those commits: a full 5-locale
+  # submission writes thousands of results/ files, and GitHub caps the file
+  # list it evaluates path filters against, so results/leaderboard.json can
+  # fall outside the evaluated set and no run is created.
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref to build from. Defaults to the triggering ref."
+        type: string
+        required: false
+        default: ""
+  # Manual escape hatch for re-publishing the current state of main.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -25,6 +39,11 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Empty for push/dispatch runs, which check out the triggering ref.
+          # Callers pass "main" so the build picks up the scoring commit that
+          # was pushed during the calling run, not the base sha it started at.
+          ref: ${{ inputs.ref }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/post-merge-score.yml
+++ b/.github/workflows/post-merge-score.yml
@@ -216,3 +216,19 @@ jobs:
           git add results/ submissions/normalized/
           git diff --cached --quiet || git commit -m "Add scoring results for ${{ steps.detect.outputs.name }}"
           git push
+
+  # Publish the site directly rather than relying on the push-path trigger in
+  # deploy-leaderboard.yml: the commit above can touch thousands of results/
+  # files, which pushes results/leaderboard.json out of the file list GitHub
+  # evaluates path filters against, and the deploy silently never runs.
+  deploy-leaderboard:
+    needs: score-and-commit
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/deploy-leaderboard.yml
+    with:
+      # Build main's tip, which now includes the scoring commit. The default
+      # ref for a pull_request_target run is the base sha from before it.
+      ref: main


### PR DESCRIPTION
## Problem

PR #53 (baseten-qwen3-asr) merged and scored fine — `Post-Merge Score` pushed 1eba04e08 with a complete `results/leaderboard.json` entry — but the provider never appeared on research.sierra.ai/mubench. No `Deploy Leaderboard` run was created for that commit; the last one was 2026-07-22.

`deploy-leaderboard.yml` triggers on pushes to main filtered to `leaderboard/**` and `results/leaderboard.json`. The baseten scoring commit touched 8,546 files (per-utterance `details/` and transcripts across 5 locales). GitHub caps the file list it evaluates path filters against, so `results/leaderboard.json` fell outside the evaluated set and no run was created. Earlier submissions were single-locale and stayed under the cap, which is why this is the first one to silently not publish.

## Fix

- `deploy-leaderboard.yml` gains `workflow_call` (with an optional `ref` input) and `workflow_dispatch`. The `push` trigger stays for ordinary `leaderboard/**` UI changes.
- `post-merge-score.yml` gains a `deploy-leaderboard` job that `needs: score-and-commit` and calls the deploy workflow, so publication is a step in the scoring pipeline rather than a side effect of path matching.
- The caller passes `ref: main`. A `pull_request_target` run's default ref is the base sha from before the scoring commit, so without this the deploy would rebuild stale data.
- Job-level `permissions` on the calling job grant `pages: write` / `id-token: write`, which a reusable workflow cannot widen on its own.

## Verification

Both files parse and expose the expected triggers/jobs. The real test is the next merged submission; in the meantime `gh workflow run deploy-leaderboard.yml --ref main` publishes baseten now (needs this PR merged first, for the dispatch trigger to exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)